### PR TITLE
Rename BigQuery CLI package to bq-util

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A modern Python project template with best practices for development and collabo
 - 🧪 Testing with [pytest](https://github.com/pytest-dev/pytest)
 - 🐳 Docker support for development and deployment
 - 👷 CI/CD with GitHub Actions
+- 📊 Production-ready BigQuery CLI built with [Click](https://click.palletsprojects.com/)
 
 ## Python Version
 This template requires Python 3.9 or higher and defaults to Python 3.12. To use a different version:
@@ -64,6 +65,76 @@ make check
 # Optional: Remove example code to start fresh
 make clean-example
 ```
+
+## BigQuery Utility CLI
+
+The repository now ships with a fully fledged BigQuery helper named `bq-util`.
+It wraps the Google Cloud BigQuery APIs with an ergonomic Click interface for
+analysing historical jobs, executing SQL files, and managing local defaults.
+
+### Installation
+
+Install the project in editable mode with the `cli` optional dependency group:
+
+```bash
+uv pip install -e .[cli]
+# or using pip
+pip install -e .[cli]
+```
+
+This pulls in `google-cloud-bigquery`, `pandas`, `InquirerPy`, and other
+required libraries. The base installation already depends on `click` and
+`rich`, so the CLI can still be imported without the optional extras (the
+commands will raise informative errors if BigQuery dependencies are missing).
+
+### Configuration
+
+`bq-util` persists configuration in the XDG config directory
+(`~/.config/bq_util/config.json` by default). Manage it from the command line:
+
+```bash
+bq-util config --show          # Display current configuration
+bq-util config --set-project my-project-id
+bq-util config --reset
+```
+
+The CLI automatically tracks the last executed job so you can re-run analysis
+with `bq-util analyze --last`.
+
+### Analysing Jobs
+
+The `analyze` command fetches detailed execution statistics, query plans, and
+human-friendly summaries:
+
+```bash
+# Interactive project and job selection
+bq-util analyze
+
+# Analyse a specific job
+bq-util analyze my-project:job_abc123
+
+# Export JSON for downstream processing
+bq-util analyze --last --format json
+```
+
+Verbose mode adds query-plan-to-SQL mapping hints, while `--llm` emits a
+machine-friendly summary for further processing.
+
+### Executing Queries
+
+Run SQL files against BigQuery directly from the CLI. The command captures job
+statistics, previews the results, and optionally triggers an immediate
+analysis:
+
+```bash
+bq-util query path/to/query.sql --project my-project --analyze
+
+# Save results to Parquet and remember the project for future runs
+bq-util query query.sql --output results.parquet --set-default-project
+```
+
+Queries that use dbt `ref()` macros are automatically rewritten to fully
+qualified table references for ad-hoc execution.
 
 ## Development Commands
 

--- a/docs/bq-util.md
+++ b/docs/bq-util.md
@@ -1,0 +1,91 @@
+# BigQuery Utility CLI
+
+The `bq-util` command line interface turns the original monolithic script into a
+modular, test-backed tool. It integrates with Google BigQuery to inspect job
+history, analyse execution plans, and run ad-hoc SQL queries.
+
+## Installation
+
+Install the project in editable mode with the optional `cli` dependency group
+to pull in the Google Cloud and pandas dependencies:
+
+```bash
+uv pip install -e .[cli]
+# or, using pip
+pip install -e .[cli]
+```
+
+The base package already depends on `click` and `rich`, so importing
+`bq_util.cli` works even when the optional dependencies are missing. Commands
+that require BigQuery gracefully notify you when the Google Cloud SDK is not
+available.
+
+## Configuration and Defaults
+
+Configuration is stored in the XDG config directory (typically
+`~/.config/bq_util/config.json`). Manage defaults via the `config` subcommand:
+
+```bash
+bq-util config --show
+bq-util config --set-project analytics-project
+bq-util config --reset
+```
+
+The CLI records the last executed job automatically so you can rerun analysis
+with `bq-util analyze --last`.
+
+## Analysing Jobs
+
+Analyse any BigQuery job by ID or interactively:
+
+```bash
+# Interactive selection: choose a project and then a job
+bq-util analyze
+
+# Specify project and job explicitly
+bq-util analyze analytics-project:job_1234
+
+# Review the most recent job saved by `bq-util query`
+bq-util analyze --last
+
+# Fetch structured JSON data for tooling integrations
+bq-util analyze --last --format json
+
+# Optimise prompt engineering workflows
+bq-util analyze --last --llm
+```
+
+Verbose output links query plan stages to the originating SQL statements to
+help you identify bottlenecks quickly.
+
+## Running Queries
+
+Run SQL files directly against BigQuery from the command line:
+
+```bash
+bq-util query path/to/query.sql --project analytics-project
+
+# Save results and run analysis automatically
+bq-util query query.sql --output results.parquet --analyze
+
+# Persist the project as the default for future commands
+bq-util query query.sql --set-default-project
+```
+
+The command shows execution statistics, previews the first few rows, and can
+store results as CSV, JSON Lines, or Parquet. Queries that contain dbt `ref()`
+macros are rewritten to fully qualified table references for quick iteration.
+
+## Optional Interactive Dependencies
+
+Interactive project and job selection is powered by
+[InquirerPy](https://github.com/kazhala/InquirerPy). If the package is not
+installed, the CLI falls back to sensible defaults and prompts for manual input
+instead of failing outright.
+
+## Testing
+
+Comprehensive unit tests exercise configuration management, query execution
+invocation, and job analysis flows using Click's `CliRunner`. The BigQuery
+client is injected via thin wrappers, keeping the code testable without network
+access or Google Cloud credentials.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ This template provides everything you need for a professional Python project:
 - 🔧 **Modern Tooling**: UV package manager, Ruff formatting/linting, MyPy type checking
 - 🧪 **Testing**: pytest with coverage reporting and CI integration
 - 📚 **Documentation**: Optional MkDocs + Material theme with auto-generation
+- 🧰 **BigQuery CLI**: Production-ready Click application with job analysis tools
 - 🚀 **CI/CD**: GitHub Actions with quality checks and automated deployment
 - 🐳 **Development**: Docker support and pre-commit hooks
 - 📦 **Packaging**: Modern pyproject.toml configuration with hatchling

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - BigQuery CLI: bq-util.md
   - Reference:
     - API Documentation: reference/api.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,10 @@ authors = [
 ]
 requires-python = ">= 3.9"
 readme = "README.md"
-dependencies = []  # No runtime dependencies needed for example
+dependencies = [
+    "click>=8.1.7",
+    "rich>=13.7.0",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -19,6 +22,16 @@ dev = [
     "tomli>=2.0.1",     # TOML reading
     "tomli-w>=1.0.0",   # TOML writing
 ]
+cli = [
+    "google-cloud-bigquery>=3.25.0",
+    "google-cloud-bigquery-storage>=2.25.0",
+    "pandas>=2.2.0",
+    "InquirerPy>=0.3.4",
+    "db-dtypes>=1.3.0",
+]
+
+[project.scripts]
+bq-util = "bq_util.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,8 @@
 #    uv pip compile pyproject.toml --extra dev -o requirements-dev.txt
 cfgv==3.4.0
     # via pre-commit
+click==8.3.0
+    # via python-collab-template (pyproject.toml)
 coverage==7.9.1
     # via pytest-cov
 distlib==0.3.9
@@ -12,6 +14,10 @@ identify==2.6.12
     # via pre-commit
 iniconfig==2.1.0
     # via pytest
+markdown-it-py==4.0.0
+    # via rich
+mdurl==0.1.2
+    # via markdown-it-py
 mypy==1.16.1
     # via python-collab-template (pyproject.toml)
 mypy-extensions==1.1.0
@@ -31,7 +37,9 @@ pluggy==1.6.0
 pre-commit==4.2.0
     # via python-collab-template (pyproject.toml)
 pygments==2.19.1
-    # via pytest
+    # via
+    #   pytest
+    #   rich
 pytest==8.4.1
     # via
     #   python-collab-template (pyproject.toml)
@@ -40,6 +48,8 @@ pytest-cov==6.2.1
     # via python-collab-template (pyproject.toml)
 pyyaml==6.0.2
     # via pre-commit
+rich==14.2.0
+    # via python-collab-template (pyproject.toml)
 ruff==0.12.0
     # via python-collab-template (pyproject.toml)
 tomli==2.2.1

--- a/src/bq_util/__init__.py
+++ b/src/bq_util/__init__.py
@@ -1,0 +1,1 @@
+"""bq_util package for the BigQuery utility CLI."""

--- a/src/bq_util/bigquery_client.py
+++ b/src/bq_util/bigquery_client.py
@@ -1,0 +1,28 @@
+"""Helpers for accessing the Google BigQuery client library."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class BigQueryDependencyError(RuntimeError):
+    """Raised when the BigQuery client library is not available."""
+
+
+def get_bigquery_client(project: str | None = None) -> Any:  # pragma: no cover - thin wrapper
+    """Return a :class:`google.cloud.bigquery.Client` instance.
+
+    The import is performed lazily so that unit tests can run without the
+    optional Google Cloud dependencies installed.
+    """
+
+    try:
+        from google.cloud import bigquery  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - exercised via CLI error handling
+        raise BigQueryDependencyError(
+            "google-cloud-bigquery is required for this command. "
+            "Install the optional 'cli' dependency group to enable BigQuery "
+            "features."
+        ) from exc
+
+    return bigquery.Client(project=project)

--- a/src/bq_util/cli.py
+++ b/src/bq_util/cli.py
@@ -1,0 +1,696 @@
+"""Command line interface for the bq-util BigQuery helper."""
+
+from __future__ import annotations
+
+import json
+from importlib import import_module
+from pathlib import Path
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, cast
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from .bigquery_client import BigQueryDependencyError, get_bigquery_client
+from .config import Config, get_config_path
+from .config import load_config as _load_config
+from .config import save_config as _save_config
+from .jobs import (
+    analyze_query_plan,
+    interactive_job_selection,
+    list_recent_jobs,
+    map_sql_to_steps,
+)
+from .projects import filter_projects, interactive_project_selection, list_projects
+from .query import (
+    format_bytes,
+    format_duration,
+    format_query_stats,
+    get_query_results_preview,
+    replace_dbt_refs,
+    run_query,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from rich.progress import Progress, TaskID
+
+
+console = Console()
+
+
+def get_config() -> Config:
+    """Wrapper to load the persisted configuration."""
+
+    return _load_config()
+
+
+def save_config(config: Config) -> None:
+    """Persist configuration changes."""
+
+    _save_config(config)
+
+
+def _load_inquirer() -> Any:
+    return import_module("InquirerPy").inquirer
+
+
+def _prompt_to_save_default(project_id: str, config: Config) -> None:
+    try:
+        inquirer = _load_inquirer()
+    except ModuleNotFoundError:
+        return
+
+    if inquirer.confirm(
+        message=f"Do you want to save {project_id} as your default project?",
+        default=True,
+    ).execute():
+        config.default_project = project_id
+        save_config(config)
+        console.print(f"[green]Saved {project_id} as your default project[/green]")
+
+
+def get_project(project_option: str | None = None) -> str:
+    """Determine which project should be used for a command."""
+
+    if project_option:
+        return project_option
+
+    config = get_config()
+    if config.default_project:
+        console.print(
+            f"[green]Using default project from config: {config.default_project}[/green]"
+        )
+        return config.default_project
+
+    projects = list_projects(console)
+    if len(projects) == 1:
+        project_id = projects[0]
+        _prompt_to_save_default(project_id, config)
+        return project_id
+    if len(projects) > 1:
+        try:
+            inquirer = _load_inquirer()
+        except ModuleNotFoundError:
+            return projects[0]
+
+        selected_projects = projects
+        if len(projects) > 25:
+            if inquirer.confirm(
+                message="Search for a specific project?",
+                default=True,
+            ).execute():
+                query = inquirer.text(message="Enter search term:").execute()
+                filtered = filter_projects(projects, query)
+                if filtered:
+                    console.print(
+                        f"[green]Found {len(filtered)} matching projects.[/green]"
+                    )
+                    selected_projects = filtered
+                else:
+                    console.print(
+                        "[yellow]No projects matched your search. Showing all projects.[/yellow]"
+                    )
+
+        project_id = interactive_project_selection(console, selected_projects)
+        return str(project_id)
+
+    console.print(
+        "[yellow]No projects found. Please enter a project ID manually.[/yellow]"
+    )
+    return cast(str, click.prompt("Enter Google Cloud project ID", type=str))
+
+
+@click.group()
+def cli() -> None:
+    """BigQuery Analysis Tool."""
+
+
+@cli.command("config")
+@click.option("--set-project", "set_project", help="Set default project ID")
+@click.option("--show", is_flag=True, help="Show current configuration")
+@click.option("--reset", is_flag=True, help="Reset configuration to defaults")
+def configure(
+    set_project: str | None = None, show: bool = False, reset: bool = False
+) -> None:
+    """Manage persistent configuration for the CLI."""
+
+    config = get_config()
+    config_path = get_config_path()
+    if not config_path.exists():
+        save_config(config)
+
+    if reset:
+        config = Config()
+        save_config(config)
+        console.print("[green]Configuration reset to defaults[/green]")
+
+    if set_project:
+        config.default_project = set_project
+        save_config(config)
+        console.print(f"[green]Default project set to: {set_project}[/green]")
+
+    if show or (not set_project and not reset):
+        console.print("[bold]Current Configuration:[/bold]")
+        table = Table()
+        table.add_column("Setting", style="cyan")
+        table.add_column("Value", style="green")
+        table.add_row("Default Project", config.default_project or "[dim]Not set[/dim]")
+        table.add_row("Config File", str(get_config_path()))
+        console.print(table)
+
+
+class ProgressContext:
+    """Context manager to wrap operations with a transient progress bar."""
+
+    def __init__(
+        self, console: Console, message: str = "[cyan]Fetching job..."
+    ) -> None:
+        self._console = console
+        self._message = message
+        self._progress: Progress | None = None
+        self._task_id: TaskID | None = None
+
+    def __enter__(self) -> Progress:
+        from rich.progress import Progress
+
+        self._progress = Progress(console=self._console, transient=True)
+        progress = self._progress.__enter__()
+        self._task_id = self._progress.add_task(self._message, total=None)
+        return progress
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        if self._progress and self._task_id is not None:
+            self._progress.update(self._task_id, completed=100)
+            self._task_id = None
+        if self._progress:
+            self._progress.__exit__(exc_type, exc, tb)
+            self._progress = None
+
+
+@cli.command("analyze")
+@click.argument("job_id", required=False)
+@click.option("--project", "project", help="Google Cloud project ID")
+@click.option("--format", "format", type=click.Choice(["text", "json"]), default="text")
+@click.option("--verbose", "verbose", is_flag=True, help="Show verbose output")
+@click.option(
+    "--llm", "llm", is_flag=True, help="Format output specifically for LLM optimisation"
+)
+@click.option(
+    "--debug", "debug", is_flag=True, help="Show debug information about job object"
+)
+@click.option(
+    "--last", "last", is_flag=True, help="Analyse the most recently executed query job"
+)
+def analyze_job(
+    job_id: str | None = None,
+    project: str | None = None,
+    format: str = "text",
+    verbose: bool = False,
+    llm: bool = False,
+    debug: bool = False,
+    last: bool = False,
+) -> None:
+    """Analyse a BigQuery job and display execution insights."""
+
+    if last:
+        config = get_config()
+        if config.last_job_id and config.last_job_project:
+            job_id = config.last_job_id
+            project = config.last_job_project
+            console.print(
+                f"[green]Using last job: {job_id} from project: {project}[/green]"
+            )
+        else:
+            console.print(
+                "[yellow]No recent job found in history. Please specify a job ID.[/yellow]"
+            )
+            return
+
+    elif job_id and ":" in job_id and not project:
+        project, job_id = job_id.split(":", 1)
+    elif job_id and not project:
+        project = get_project()
+    elif project and not job_id:
+        try:
+            client = get_bigquery_client(project=project)
+        except BigQueryDependencyError as exc:
+            raise click.ClickException(str(exc)) from exc
+        jobs = list_recent_jobs(client, console)
+        job_id = interactive_job_selection(console, jobs)
+    elif not job_id and not project:
+        project = get_project()
+        try:
+            client = get_bigquery_client(project=project)
+        except BigQueryDependencyError as exc:
+            raise click.ClickException(str(exc)) from exc
+        jobs = list_recent_jobs(client, console)
+        job_id = interactive_job_selection(console, jobs)
+
+    if not project or not job_id:
+        raise click.ClickException("A project and job id are required for analysis")
+
+    try:
+        client = get_bigquery_client(project=project)
+    except BigQueryDependencyError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    with ProgressContext(console, message=f"[cyan]Fetching job {job_id}..."):
+        job = client.get_job(job_id, project=project)
+
+    if debug:
+        console.print("\n[bold]Debug Information:[/bold]")
+        console.print("[bold]Job Attributes:[/bold]")
+        for attr in dir(job):
+            if not attr.startswith("_"):
+                try:
+                    value = getattr(job, attr)
+                except Exception as exc:  # pragma: no cover - diagnostic path
+                    console.print(f"- {attr}: Error accessing: {exc}")
+                else:
+                    console.print(f"- {attr}: {type(value)}")
+
+    job_info = {
+        "job_id": job.job_id,
+        "project": job.project,
+        "location": job.location,
+        "created": job.created.isoformat() if getattr(job, "created", None) else None,
+        "state": job.state,
+        "error_result": job.error_result,
+        "user_email": getattr(job, "user_email", None),
+        "job_type": job.job_type,
+    }
+
+    if getattr(job, "started", None):
+        job_info["started"] = job.started.isoformat()
+        if getattr(job, "ended", None):
+            job_info["ended"] = job.ended.isoformat()
+            job_info["duration"] = format_duration(job.started, job.ended)
+
+    if job.job_type == "query":
+        query_info: dict[str, Any] = {
+            "query": job.query,
+            "bytes_processed": job.total_bytes_processed,
+            "bytes_processed_formatted": format_bytes(job.total_bytes_processed),
+            "slot_ms": job.slot_millis,
+            "billing_tier": getattr(job, "billing_tier", None),
+            "cache_hit": job.cache_hit,
+        }
+
+        if getattr(job, "destination", None):
+            destination = job.destination
+            if hasattr(destination, "project"):
+                query_info["destination_table"] = {
+                    "project": destination.project,
+                    "dataset": destination.dataset_id,
+                    "table": destination.table_id,
+                }
+            else:
+                query_info["destination_table"] = str(destination)
+
+        if job.state == "DONE":
+            if getattr(job, "query_plan", None):
+                query_info["query_plan"] = []
+                for step in job.query_plan:
+                    query_info["query_plan"].append(
+                        {
+                            "name": step.name,
+                            "entry_id": step.entry_id,
+                            "input_stages": step.input_stages,
+                            "start": getattr(step, "start", None),
+                            "end": getattr(step, "end", None),
+                            "records_read": getattr(step, "records_read", None),
+                            "records_written": getattr(step, "records_written", None),
+                            "status": getattr(step, "status", None),
+                            "shuffle_output_bytes": getattr(
+                                step, "shuffle_output_bytes", None
+                            ),
+                            "slot_ms": getattr(step, "slot_ms", None),
+                            "compute_ms_avg": getattr(step, "compute_ms_avg", None),
+                            "compute_ms_max": getattr(step, "compute_ms_max", None),
+                            "wait_ms_avg": getattr(step, "wait_ms_avg", None),
+                            "wait_ms_max": getattr(step, "wait_ms_max", None),
+                        }
+                    )
+
+                query_info["query_plan_analysis"] = analyze_query_plan(job)
+                if job.query:
+                    query_info["sql_mapping"] = map_sql_to_steps(
+                        job.query, job.query_plan
+                    )
+            else:
+                query_info["query_plan"] = []
+
+            query_info["referenced_tables"] = [
+                str(table) for table in getattr(job, "referenced_tables", [])
+            ]
+
+        job_info["query_details"] = query_info
+
+    if llm:
+        llm_output: dict[str, Any] = {
+            "query": job.query if job.job_type == "query" else "",
+            "performance_data": {
+                "bytes_processed": job.total_bytes_processed
+                if job.job_type == "query"
+                else 0,
+                "bytes_processed_human": format_bytes(job.total_bytes_processed),
+                "slot_milliseconds": job.slot_millis if job.job_type == "query" else 0,
+                "duration_seconds": (job.ended - job.started).total_seconds()
+                if getattr(job, "started", None) and getattr(job, "ended", None)
+                else 0,
+                "cache_hit": job.cache_hit if job.job_type == "query" else False,
+            },
+        }
+
+        if job.job_type == "query" and getattr(job, "query_plan", None):
+            analysis = analyze_query_plan(job)
+            if analysis.get("top_time_steps"):
+                llm_output["top_time_consuming_steps"] = [
+                    {
+                        "step_id": step.entry_id,
+                        "name": step.name,
+                        "slot_ms": step.slot_ms,
+                        "percentage_of_total": (step.slot_ms / job.slot_millis) * 100
+                        if job.slot_millis
+                        else 0,
+                    }
+                    for step in analysis["top_time_steps"]
+                ]
+
+            if analysis.get("top_data_steps"):
+                llm_output["top_data_processing_steps"] = [
+                    {
+                        "step_id": step.entry_id,
+                        "name": step.name,
+                        "records_read": step.records_read,
+                        "records_written": getattr(step, "records_written", None),
+                    }
+                    for step in analysis["top_data_steps"]
+                ]
+
+            if analysis.get("bottlenecks"):
+                llm_output["bottlenecks"] = analysis["bottlenecks"]
+
+        click.echo(json.dumps(llm_output, indent=2))
+        return
+
+    if format == "json":
+        click.echo(json.dumps(job_info, indent=2))
+        return
+
+    console.print(Panel.fit(f"[bold]BigQuery Job: {job.job_id}[/bold]"))
+    console.print(f"[bold]Status:[/bold] {job.state}")
+    console.print(f"[bold]Type:[/bold] {job.job_type}")
+    console.print(f"[bold]User:[/bold] {getattr(job, 'user_email', 'Unknown')}")
+    console.print(f"[bold]Created:[/bold] {job.created.isoformat()}")
+
+    if getattr(job, "started", None):
+        console.print(f"[bold]Started:[/bold] {job.started.isoformat()}")
+        if getattr(job, "ended", None):
+            console.print(f"[bold]Ended:[/bold] {job.ended.isoformat()}")
+            console.print(
+                f"[bold]Duration:[/bold] {format_duration(job.started, job.ended)}"
+            )
+
+    if job.error_result:
+        console.print("[bold red]Error:[/bold red]", job.error_result)
+        console.print(
+            "[bold red]No query plan or execution details will be present in this report[/bold red]"
+        )
+
+    if job.job_type == "query":
+        console.print("\n[bold]Query Details:[/bold]")
+        console.print(f"[bold]Query:[/bold]\n{job.query}")
+
+        if job.total_bytes_processed:
+            console.print(
+                f"[bold]Bytes Processed:[/bold] {format_bytes(job.total_bytes_processed)}"
+            )
+
+        console.print(f"[bold]Cache Hit:[/bold] {job.cache_hit}")
+
+        if getattr(job, "query_plan", None):
+            console.print("\n[bold]Query Plan:[/bold]")
+            plan_table = Table(title="Query Execution Plan - Performance Analysis")
+            plan_table.add_column("ID", style="cyan", width=5)
+            plan_table.add_column("Name", style="green")
+            plan_table.add_column("Records\nRead", style="blue", justify="right")
+            plan_table.add_column("Records\nWritten", style="magenta", justify="right")
+            plan_table.add_column("Shuffle\nBytes", style="yellow", justify="right")
+            plan_table.add_column("Slot MS", style="white", justify="right")
+
+            if verbose:
+                plan_table.add_column("Wait\nMS Avg", style="red", justify="right")
+                plan_table.add_column("Compute\nMS Avg", style="green", justify="right")
+
+            max_slot_ms = max((step.slot_ms or 0) for step in job.query_plan)
+            max_records_read = max((step.records_read or 0) for step in job.query_plan)
+            max_shuffle = max(
+                (getattr(step, "shuffle_output_bytes", 0) or 0)
+                for step in job.query_plan
+            )
+
+            for step in job.query_plan:
+                records_read = (
+                    f"{step.records_read:,}"
+                    if getattr(step, "records_read", None)
+                    else "-"
+                )
+                records_written = (
+                    f"{step.records_written:,}"
+                    if getattr(step, "records_written", None)
+                    else "-"
+                )
+                shuffle_bytes = (
+                    format_bytes(step.shuffle_output_bytes)
+                    if getattr(step, "shuffle_output_bytes", None)
+                    else "-"
+                )
+                slot_ms = f"{step.slot_ms:,}" if getattr(step, "slot_ms", None) else "-"
+
+                slot_style = (
+                    "bold red"
+                    if getattr(step, "slot_ms", 0) and step.slot_ms > max_slot_ms * 0.7
+                    else "white"
+                )
+                read_style = (
+                    "bold blue"
+                    if getattr(step, "records_read", 0)
+                    and step.records_read > max_records_read * 0.7
+                    else "blue"
+                )
+                shuffle_style = (
+                    "bold yellow"
+                    if getattr(step, "shuffle_output_bytes", 0)
+                    and step.shuffle_output_bytes > max_shuffle * 0.7
+                    else "yellow"
+                )
+
+                if verbose:
+                    wait_ms = (
+                        f"{step.wait_ms_avg:,.1f}"
+                        if getattr(step, "wait_ms_avg", None)
+                        else "-"
+                    )
+                    compute_ms = (
+                        f"{step.compute_ms_avg:,.1f}"
+                        if getattr(step, "compute_ms_avg", None)
+                        else "-"
+                    )
+                    plan_table.add_row(
+                        str(step.entry_id),
+                        step.name,
+                        f"[{read_style}]{records_read}[/{read_style}]",
+                        records_written,
+                        f"[{shuffle_style}]{shuffle_bytes}[/{shuffle_style}]",
+                        f"[{slot_style}]{slot_ms}[/{slot_style}]",
+                        wait_ms,
+                        compute_ms,
+                    )
+                else:
+                    plan_table.add_row(
+                        str(step.entry_id),
+                        step.name,
+                        f"[{read_style}]{records_read}[/{read_style}]",
+                        records_written,
+                        f"[{shuffle_style}]{shuffle_bytes}[/{shuffle_style}]",
+                        f"[{slot_style}]{slot_ms}[/{slot_style}]",
+                    )
+
+            console.print(plan_table)
+
+            console.print("\n[bold]Performance Insights:[/bold]")
+            top_steps_by_time = sorted(
+                [step for step in job.query_plan if getattr(step, "slot_ms", None)],
+                key=lambda step: step.slot_ms or 0,
+                reverse=True,
+            )[:3]
+
+            if top_steps_by_time:
+                console.print("[bold]Top Time-Consuming Steps:[/bold]")
+                for step in top_steps_by_time:
+                    pct = (
+                        (step.slot_ms / job.slot_millis) * 100 if job.slot_millis else 0
+                    )
+                    console.print(
+                        f"  Step {step.entry_id}: {step.name} - {format_duration(None, None, milliseconds=step.slot_ms)} "
+                        f"({pct:.1f}% of total)"
+                    )
+
+            top_steps_by_data = sorted(
+                [
+                    step
+                    for step in job.query_plan
+                    if getattr(step, "records_read", None)
+                ],
+                key=lambda step: step.records_read or 0,
+                reverse=True,
+            )[:3]
+
+            if top_steps_by_data:
+                console.print("[bold]Top Data-Processing Steps:[/bold]")
+                for step in top_steps_by_data:
+                    console.print(
+                        f"  Step {step.entry_id}: {step.name} - {step.records_read:,} records read"
+                    )
+
+            if verbose and job.query:
+                sql_mapping = map_sql_to_steps(job.query, job.query_plan)
+                if sql_mapping:
+                    console.print(
+                        "\n[bold]Query Plan to SQL Mapping (Approximate):[/bold]"
+                    )
+                    console.print(
+                        "[yellow]Note: This is a best-effort mapping and may not be fully accurate[/yellow]"
+                    )
+                    for mapping in sql_mapping:
+                        console.print(
+                            f"[bold]Step {mapping['step_id']} ({mapping['step_name']})[/bold] may relate to:"
+                        )
+                        for line_num, line in mapping["matching_lines"]:
+                            console.print(
+                                f"  Line {line_num + 1}: [green]{line}[/green]"
+                            )
+
+
+@cli.command("query")
+@click.argument("query_file", type=click.Path(exists=True, readable=True))
+@click.option("--project", "project", help="Google Cloud project ID")
+@click.option(
+    "--analyze", "analyze", is_flag=True, help="Run analyze command on the query job"
+)
+@click.option("--verbose", "verbose", is_flag=True, help="Show verbose output")
+@click.option(
+    "--output", "output", type=click.Path(), help="Save query results to a file"
+)
+@click.option(
+    "--preview-rows",
+    "preview_rows",
+    type=int,
+    default=5,
+    help="Number of rows to preview",
+)
+@click.option(
+    "--set-default-project",
+    "set_default_project",
+    is_flag=True,
+    help="Set the project as default",
+)
+def execute_query(
+    query_file: str,
+    project: str | None = None,
+    analyze: bool = False,
+    verbose: bool = False,
+    output: str | None = None,
+    preview_rows: int = 5,
+    set_default_project: bool = False,
+) -> None:
+    """Execute a SQL query from ``query_file`` against BigQuery."""
+
+    query_path = Path(query_file)
+
+    try:
+        query = query_path.read_text(encoding="utf-8")
+    except Exception as exc:
+        raise click.ClickException(f"Unable to read file: {exc}") from exc
+
+    console.print(Panel(f"Processing query from {query_file}", style="cyan"))
+
+    project = get_project(project)
+
+    if set_default_project:
+        config = get_config()
+        config.default_project = project
+        save_config(config)
+        console.print(f"[green]Saved {project} as your default project[/green]")
+
+    processed_query = replace_dbt_refs(query, project) if "{{ ref(" in query else query
+
+    if verbose:
+        console.print(Panel(processed_query, title="Processed Query", style="dim"))
+
+    try:
+        job, execution_time = run_query(processed_query, project)
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    console.print(
+        f"[green]Query completed successfully in {execution_time:.2f} seconds![/green]"
+    )
+
+    config = get_config()
+    config.last_job_id = job.job_id
+    config.last_job_project = project
+    save_config(config)
+
+    console.print(format_query_stats(job, execution_time))
+    console.print(get_query_results_preview(job, max_rows=preview_rows))
+
+    if output:
+        from rich.progress import Progress
+
+        dataframe = job.to_dataframe()
+        with Progress(console=console, transient=True) as progress:
+            task = progress.add_task("[cyan]Saving results...", total=None)
+            saved_path = _write_dataframe(dataframe, output)
+            progress.update(task, completed=100)
+        console.print(f"[green]Results saved to {saved_path}[/green]")
+
+    console.print(f"\n[dim]Job ID: {job.job_id}[/dim]")
+
+    if analyze:
+        console.print("\n[cyan]Running detailed analysis on the query job...[/cyan]")
+        analyze_job(job.job_id, project, verbose=verbose)
+    else:
+        console.print("[dim]To analyse this query, run either:[/dim]")
+        console.print(f"[cyan]bq-util analyze {job.job_id} --project {project}[/cyan]")
+        console.print("[dim]Or simply use:[/dim]")
+        console.print("[cyan]bq-util analyze --last[/cyan]")
+
+
+def _write_dataframe(dataframe: Any, output: str) -> Path:
+    path = Path(output)
+    suffix = path.suffix.lower()
+
+    if suffix == ".csv":
+        dataframe.to_csv(path, index=False)
+    elif suffix == ".json":
+        dataframe.to_json(path, orient="records", lines=True)
+    elif suffix == ".parquet":
+        dataframe.to_parquet(path, index=False)
+    else:
+        path = path.with_suffix(".csv")
+        dataframe.to_csv(path, index=False)
+
+    return path
+
+
+def main() -> None:  # pragma: no cover - entry point helper
+    cli()

--- a/src/bq_util/config.py
+++ b/src/bq_util/config.py
@@ -1,0 +1,73 @@
+"""Configuration management for the bq_util CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+APP_NAME = "bq_util"
+CONFIG_FILENAME = "config.json"
+
+
+@dataclass()
+class Config:
+    """Simple container for persisted configuration values."""
+
+    default_project: str | None = None
+    last_job_id: str | None = None
+    last_job_project: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Config:
+        """Create a :class:`Config` instance from persisted JSON data."""
+
+        return cls(
+            default_project=data.get("default_project"),
+            last_job_id=data.get("last_job_id"),
+            last_job_project=data.get("last_job_project"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise the configuration to a JSON compatible dictionary."""
+
+        return asdict(self)
+
+
+def get_config_dir() -> Path:
+    """Return the directory used to store configuration files."""
+
+    base = os.environ.get("XDG_CONFIG_HOME")
+    base_path = Path(base).expanduser() if base else Path.home() / ".config"
+    return base_path / APP_NAME
+
+
+def get_config_path() -> Path:
+    """Return the location of the configuration file."""
+
+    return get_config_dir() / CONFIG_FILENAME
+
+
+def load_config(path: Path | None = None) -> Config:
+    """Load configuration from ``path`` or return defaults if missing."""
+
+    config_path = path or get_config_path()
+    if not config_path.exists():
+        return Config()
+
+    try:
+        raw_data = json.loads(config_path.read_text())
+    except Exception:
+        return Config()
+
+    return Config.from_dict(raw_data)
+
+
+def save_config(config: Config, path: Path | None = None) -> None:
+    """Persist the provided configuration to disk."""
+
+    config_path = path or get_config_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config.to_dict(), indent=2))

--- a/src/bq_util/jobs.py
+++ b/src/bq_util/jobs.py
@@ -1,0 +1,256 @@
+"""Job discovery and analysis helpers for the bq_util CLI."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from datetime import datetime, timedelta, timezone
+from importlib import import_module
+from typing import Any
+
+from rich.console import Console
+from rich.progress import Progress
+from rich.table import Table
+
+
+def list_recent_jobs(
+    client: Any, console: Console, max_results: int = 20
+) -> list[dict[str, Any]]:
+    """Return metadata for recent jobs owned by the current user."""
+
+    jobs: list[dict[str, Any]] = []
+
+    with Progress(console=console, transient=True) as progress:
+        task = progress.add_task("[cyan]Fetching recent jobs...", total=None)
+        seven_days_ago = datetime.now(timezone.utc) - timedelta(days=7)
+
+        try:
+            iterator = client.list_jobs(
+                max_results=max_results,
+                min_creation_time=seven_days_ago,
+                all_users=False,
+            )
+        except Exception as exc:  # pragma: no cover - dependent on client behaviour
+            console.print(f"[yellow]Warning when fetching jobs: {exc}")
+            return []
+
+        for job in iterator:
+            job_info = {
+                "job_id": job.job_id,
+                "created": job.created,
+                "state": job.state,
+                "job_type": job.job_type,
+                "display": f"{job.job_type.upper()}: {job.job_id} ({job.state}) - "
+                f"{job.created.strftime('%Y-%m-%d %H:%M:%S')}",
+            }
+
+            if job.job_type == "query" and getattr(job, "query", None):
+                query = job.query.replace("\n", " ")
+                preview = query[:50] + ("..." if len(query) > 50 else "")
+                job_info["query_preview"] = preview
+                job_info["display"] = (
+                    f"QUERY: {preview} ({job.state}) - "
+                    f"{job.created.strftime('%Y-%m-%d %H:%M:%S')}"
+                )
+
+            jobs.append(job_info)
+
+        progress.update(task, completed=100)
+
+    return sorted(jobs, key=lambda entry: entry["created"], reverse=True)
+
+
+def filter_jobs(jobs: Iterable[dict[str, Any]], query: str) -> list[dict[str, Any]]:
+    """Filter job metadata using a case-insensitive query."""
+
+    if not query:
+        return list(jobs)
+
+    pattern = re.compile(f".*{re.escape(query)}.*", re.IGNORECASE)
+    return [
+        job
+        for job in jobs
+        if pattern.match(job["job_id"]) or pattern.match(job.get("query_preview", ""))
+    ]
+
+
+def interactive_job_selection(console: Console, jobs: list[dict[str, Any]]) -> str:
+    """Prompt the user to pick a job from ``jobs`` or enter an id manually."""
+
+    if not jobs:
+        raise RuntimeError("No recent jobs found")
+
+    try:
+        inquirer = import_module("InquirerPy").inquirer
+        choice_module = import_module("InquirerPy.base.control")
+        choice_cls = choice_module.Choice
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "Interactive job selection requires InquirerPy. Install the optional "
+            "'cli' dependency group or provide a job id explicitly."
+        ) from exc
+
+    table = Table(title="Recent BigQuery Jobs")
+    table.add_column("Job ID", style="cyan")
+    table.add_column("Type", style="green")
+    table.add_column("State", style="yellow")
+    table.add_column("Created", style="blue")
+    table.add_column("Query Preview", style="white")
+
+    for job in jobs[:10]:
+        preview = job.get("query_preview", "")
+        display_preview = preview[:50] + ("..." if len(preview) > 50 else "")
+        job_id = job["job_id"]
+        if len(job_id) > 30:
+            job_id = job_id[:27] + "..."
+        table.add_row(
+            job_id,
+            job["job_type"].upper(),
+            job["state"],
+            job["created"].strftime("%Y-%m-%d %H:%M:%S"),
+            display_preview,
+        )
+
+    console.print(table)
+
+    choices = [
+        choice_cls(
+            value=job["job_id"],
+            name=job.get("display", job["job_id"]),
+        )
+        for job in jobs
+    ]
+    choices.append(choice_cls(value="manual", name="Enter job ID manually"))
+
+    selected = inquirer.select(  # pragma: no cover - requires interactive terminal
+        message="Select a job to analyse:",
+        choices=choices,
+        default=choices[0].value if choices else None,
+    ).execute()
+
+    if selected == "manual":  # pragma: no cover - interactive path
+        return str(inquirer.text(message="Enter job ID:").execute())
+    return str(selected)
+
+
+def analyze_query_plan(job: Any) -> dict[str, Any]:
+    """Derive key insights from a BigQuery query plan."""
+
+    plan = getattr(job, "query_plan", None)
+    if not plan:
+        return {}
+
+    steps = [step for step in plan if getattr(step, "slot_ms", None)]
+    sorted_by_time = sorted(steps, key=lambda step: step.slot_ms or 0, reverse=True)
+    sorted_by_records = sorted(
+        [step for step in plan if getattr(step, "records_read", None)],
+        key=lambda step: step.records_read or 0,
+        reverse=True,
+    )
+    sorted_by_shuffle = sorted(
+        [step for step in plan if getattr(step, "shuffle_output_bytes", None)],
+        key=lambda step: step.shuffle_output_bytes or 0,
+        reverse=True,
+    )
+
+    bottlenecks: list[dict[str, Any]] = []
+    total_slot_ms = getattr(job, "slot_millis", 0) or 0
+
+    if total_slot_ms and sorted_by_time:
+        for step in sorted_by_time[:3]:
+            pct = (step.slot_ms / total_slot_ms) * 100 if step.slot_ms else 0
+            if pct > 25:
+                bottlenecks.append(
+                    {
+                        "type": "time",
+                        "step_id": step.entry_id,
+                        "name": step.name,
+                        "percentage": pct,
+                    }
+                )
+
+    if sorted_by_records:
+        for step in sorted_by_records[:2]:
+            bottlenecks.append(
+                {
+                    "type": "data",
+                    "step_id": step.entry_id,
+                    "name": step.name,
+                    "records": step.records_read,
+                }
+            )
+
+    if sorted_by_shuffle:
+        for step in sorted_by_shuffle[:2]:
+            bottlenecks.append(
+                {
+                    "type": "shuffle",
+                    "step_id": step.entry_id,
+                    "name": step.name,
+                    "bytes": step.shuffle_output_bytes,
+                }
+            )
+
+    return {
+        "steps_count": len(plan),
+        "bottlenecks": bottlenecks,
+        "top_time_steps": sorted_by_time[:3],
+        "top_data_steps": sorted_by_records[:3],
+        "top_shuffle_steps": sorted_by_shuffle[:3],
+    }
+
+
+def map_sql_to_steps(query: str, plan: Iterable[Any]) -> list[dict[str, Any]]:
+    """Approximate mapping between SQL fragments and plan steps."""
+
+    if not query or not plan:
+        return []
+
+    operations_map = {
+        "read": ["FROM", "TABLE"],
+        "filter": ["WHERE", "HAVING"],
+        "aggregate": ["GROUP BY", "COUNT", "SUM", "AVG", "MIN", "MAX"],
+        "join": ["JOIN", "INNER JOIN", "LEFT JOIN", "RIGHT JOIN"],
+        "sort": ["ORDER BY"],
+        "window": ["OVER", "PARTITION BY"],
+        "compute": ["SELECT", "CASE", "WHEN"],
+        "limit": ["LIMIT"],
+        "union": ["UNION"],
+        "intersect": ["INTERSECT"],
+        "except": ["EXCEPT"],
+    }
+
+    query_lines = [line.strip() for line in query.splitlines() if line.strip()]
+    mappings: list[dict[str, Any]] = []
+
+    for step in plan:
+        step_name = getattr(step, "name", "").lower()
+        matched_keywords: list[str] = []
+
+        for operation, keywords in operations_map.items():
+            if operation in step_name:
+                matched_keywords.extend(keywords)
+
+        if not matched_keywords and "input" in step_name:
+            matched_keywords = ["FROM", "TABLE"]
+        elif not matched_keywords and "output" in step_name:
+            matched_keywords = ["SELECT", "INTO"]
+
+        matching_lines = []
+        for line_number, line in enumerate(query_lines):
+            for keyword in matched_keywords:
+                pattern = re.compile(rf"\\b{re.escape(keyword)}\\b", re.IGNORECASE)
+                if pattern.search(line):
+                    matching_lines.append((line_number, line))
+                    break
+
+        if matching_lines:
+            mappings.append(
+                {
+                    "step_id": getattr(step, "entry_id", None),
+                    "step_name": getattr(step, "name", ""),
+                    "matching_lines": matching_lines,
+                }
+            )
+
+    return mappings

--- a/src/bq_util/projects.py
+++ b/src/bq_util/projects.py
@@ -1,0 +1,94 @@
+"""Utilities for discovering and selecting Google Cloud projects."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from collections.abc import Iterable
+from importlib import import_module
+
+from rich.console import Console
+from rich.progress import Progress
+
+
+def list_projects(console: Console) -> list[str]:
+    """Return a list of active projects visible to ``gcloud``."""
+
+    gcloud_executable = shutil.which("gcloud")
+    if not gcloud_executable:  # pragma: no cover - dependent on environment
+        console.print(
+            "[yellow]Warning: gcloud is not available; project discovery is disabled.[/yellow]"
+        )
+        return []
+
+    try:
+        subprocess.run(  # noqa: S603
+            [gcloud_executable, "--version"], capture_output=True, check=True
+        )
+    except Exception as exc:  # pragma: no cover - dependent on environment
+        console.print(
+            "[yellow]Warning: gcloud is not available; project discovery is "
+            "disabled.[/yellow]"
+        )
+        console.print(str(exc))
+        return []
+
+    try:
+        with Progress(console=console, transient=True) as progress:
+            task = progress.add_task("[cyan]Fetching projects...", total=None)
+            result = subprocess.run(  # noqa: S603
+                [gcloud_executable, "projects", "list", "--format=json"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            progress.update(task, completed=100)
+    except Exception as exc:  # pragma: no cover - dependent on environment
+        console.print(
+            "[yellow]Warning: Unable to retrieve project list. Falling back "
+            "to configured defaults.[/yellow]"
+        )
+        console.print(str(exc))
+        return []
+
+    data = json.loads(result.stdout)
+    return [
+        item["projectId"] for item in data if item.get("lifecycleState") == "ACTIVE"
+    ]
+
+
+def filter_projects(projects: Iterable[str], query: str) -> list[str]:
+    """Return projects whose identifiers match ``query`` (case insensitive)."""
+
+    if not query:
+        return list(projects)
+
+    pattern = re.compile(f".*{re.escape(query)}.*", re.IGNORECASE)
+    return [project for project in projects if pattern.match(project)]
+
+
+def interactive_project_selection(console: Console, projects: list[str]) -> str:
+    """Prompt the user to select a project from ``projects``."""
+
+    if not projects:
+        raise ValueError("No projects available for selection")
+
+    if len(projects) == 1:
+        return projects[0]
+
+    try:
+        inquirer = import_module("InquirerPy").inquirer
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "Interactive selection requires InquirerPy. Install the optional "
+            "'cli' dependencies or specify --project explicitly."
+        ) from exc
+
+    selection = inquirer.select(  # pragma: no cover - requires interactive terminal
+        message="Select GCP project:",
+        choices=projects,
+        default=projects[0],
+    ).execute()
+    return str(selection)

--- a/src/bq_util/query.py
+++ b/src/bq_util/query.py
@@ -1,0 +1,163 @@
+"""Query execution utilities for the bq_util CLI."""
+
+from __future__ import annotations
+
+import re
+import time
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from .bigquery_client import BigQueryDependencyError, get_bigquery_client
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from rich.table import Table
+
+
+def format_bytes(bytes_value: int | None) -> str:
+    """Return a human-readable byte representation."""
+
+    if not bytes_value:
+        return "0 B"
+
+    value = float(bytes_value)
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if value < 1024.0:
+            return f"{value:.2f} {unit}"
+        value /= 1024.0
+    return f"{value:.2f} PB"
+
+
+def format_duration(
+    start_time: datetime | None,
+    end_time: datetime | None,
+    milliseconds: int | None = None,
+) -> str:
+    """Convert a duration into a human-friendly string."""
+
+    if milliseconds is not None:
+        duration = milliseconds / 1000.0
+    elif start_time is None or end_time is None:
+        return "Running..."
+    else:
+        duration = (end_time - start_time).total_seconds()
+
+    minutes, seconds = divmod(duration, 60)
+    hours, minutes = divmod(minutes, 60)
+
+    if hours > 0:
+        return f"{int(hours)}h {int(minutes)}m {seconds:.2f}s"
+    if minutes > 0:
+        return f"{int(minutes)}m {seconds:.2f}s"
+    return f"{seconds:.2f}s"
+
+
+def extract_table_references(query: str) -> list[str]:
+    """Return table references found in ``query``."""
+
+    pattern = r"FROM\s+[`]?{{?\s*ref\(['\"]([\w_]+)['\"](?:,\s*['\"][\w_]+['\"])?\s*\)}\}?[`]?"
+    tables = re.findall(pattern, query, re.IGNORECASE)
+    pattern_direct = r"FROM\s+[`]?([\w\._]+)[`]?"
+    tables.extend(re.findall(pattern_direct, query, re.IGNORECASE))
+    return tables
+
+
+def replace_dbt_refs(query: str, project: str) -> str:
+    """Replace ``dbt`` ``ref`` macros with fully qualified table names."""
+
+    pattern = r"{{[\s]*ref\(['\"](\w+)['\"](?:,[\s]*['\"](\w+)['\"])?[\s]*\)[\s]*}}"
+
+    def _replace(match: re.Match[str]) -> str:
+        table = match.group(1)
+        if match.group(2):
+            table = match.group(2)
+        return f"`{project}.dbt_testing.{table}`"
+
+    modified_query = re.sub(pattern, _replace, query)
+
+    yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+    today = datetime.now().strftime("%Y-%m-%d")
+    modified_query = modified_query.replace(
+        "{{ start_date() }}", f"'{yesterday} 00:00:00'"
+    )
+    modified_query = modified_query.replace("{{ end_date() }}", f"'{today} 00:00:00'")
+
+    return modified_query
+
+
+def run_query(
+    query: str, project: str
+) -> tuple[Any, float]:  # pragma: no cover - integration path
+    """Execute ``query`` against BigQuery returning the job and execution time."""
+
+    try:
+        client = get_bigquery_client(project=project)
+    except BigQueryDependencyError as exc:  # pragma: no cover - CLI error surface
+        raise RuntimeError(str(exc)) from exc
+
+    start = time.time()
+    job = client.query(query)
+    job.result()
+    execution_time = time.time() - start
+    return job, execution_time
+
+
+def format_query_stats(job: Any, execution_time: float) -> Table:
+    """Create a rich table describing query statistics."""
+
+    from rich.table import Table
+
+    stats_table = Table(title="Query Statistics")
+    stats_table.add_column("Metric", style="cyan")
+    stats_table.add_column("Value", style="green")
+
+    bytes_processed = getattr(job, "total_bytes_processed", 0) or 0
+    stats_table.add_row("Execution Time", f"{execution_time:.2f} seconds")
+    stats_table.add_row(
+        "Bytes Processed",
+        f"{bytes_processed:,} bytes ({bytes_processed / 1073741824 if bytes_processed else 0:.2f} GB)",
+    )
+
+    bytes_billed = getattr(job, "total_bytes_billed", 0) or 0
+    stats_table.add_row(
+        "Bytes Billed",
+        f"{bytes_billed:,} bytes ({bytes_billed / 1073741824 if bytes_billed else 0:.2f} GB)",
+    )
+
+    slot_millis = getattr(job, "slot_millis", 0) or 0
+    stats_table.add_row(
+        "Slot Time", f"{slot_millis / 1000 if slot_millis else 0:.2f} seconds"
+    )
+
+    referenced_tables = getattr(job, "referenced_tables", None)
+    if referenced_tables:
+        table_lines = []
+        for table in referenced_tables:
+            if hasattr(table, "project") and hasattr(table, "dataset_id"):
+                table_lines.append(
+                    f"{table.project}.{table.dataset_id}.{table.table_id}"
+                )
+            else:
+                table_lines.append(str(table))
+        stats_table.add_row("Referenced Tables", "\n".join(table_lines))
+
+    return stats_table
+
+
+def get_query_results_preview(job: Any, max_rows: int = 5) -> Table:
+    """Return a preview of query results as a rich table."""
+
+    from rich.table import Table
+
+    dataframe = job.to_dataframe().head(max_rows)
+
+    preview_table = Table(
+        title=f"Results Preview (first {min(max_rows, len(dataframe))} rows)"
+    )
+    for column in dataframe.columns:
+        preview_table.add_column(str(column))
+
+    for _, row in dataframe.iterrows():
+        values = [str(value) for value in row]
+        preview_table.add_row(*values)
+
+    return preview_table

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+"""Test package configuration."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -1,0 +1,74 @@
+"""Tests for the analyze command in the bq-util CLI."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from click.testing import CliRunner
+
+import bq_util.cli as cli_module
+
+
+class FakeJob:
+    """A tiny subset of the QueryJob interface used in the CLI."""
+
+    def __init__(self) -> None:
+        now = datetime.now(timezone.utc)
+        self.job_id = "recent-job"
+        self.project = "demo-project"
+        self.location = "us-central1"
+        self.created = now - timedelta(minutes=5)
+        self.started = self.created
+        self.ended = now
+        self.state = "DONE"
+        self.error_result = None
+        self.user_email = "user@example.com"
+        self.job_type = "query"
+        self.query = "SELECT 1"
+        self.total_bytes_processed = 100
+        self.total_bytes_billed = 100
+        self.slot_millis = 1000
+        self.billing_tier = None
+        self.cache_hit = False
+        self.destination = None
+        self.query_plan: list[Any] = []
+        self.referenced_tables: list[Any] = []
+
+
+class FakeClient:
+    def __init__(self, job: FakeJob) -> None:
+        self._job = job
+
+    def get_job(self, job_id: str, project: str | None = None) -> FakeJob:
+        assert job_id == self._job.job_id
+        assert project == self._job.project
+        return self._job
+
+
+def test_analyze_uses_last_job_from_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    config_dir = tmp_path / "bq_util"
+    config_dir.mkdir()
+    (config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "default_project": None,
+                "last_job_id": "recent-job",
+                "last_job_project": "demo-project",
+            }
+        )
+    )
+
+    fake_job = FakeJob()
+    monkeypatch.setattr(
+        cli_module, "get_bigquery_client", lambda project=None: FakeClient(fake_job)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli_module.cli, ["analyze", "--last", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert "recent-job" in result.output

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,46 @@
+"""Tests for the configuration command of the bq-util CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bq_util.cli import cli
+
+
+def _read_config(base_dir: Path) -> dict[str, object | None]:
+    config_file = base_dir / "bq_util" / "config.json"
+    assert config_file.exists(), "expected configuration file to be written"
+    return json.loads(config_file.read_text())
+
+
+def test_config_show_initialises_file(tmp_path, monkeypatch):
+    """Showing the config should create a config file with defaults."""
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["config", "--show"])
+
+    assert result.exit_code == 0, result.output
+    config = _read_config(tmp_path)
+    assert config == {
+        "default_project": None,
+        "last_job_id": None,
+        "last_job_project": None,
+    }
+
+
+def test_config_set_project_persists(tmp_path, monkeypatch):
+    """Setting the default project should persist to the config file."""
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["config", "--set-project", "demo-project"])
+
+    assert result.exit_code == 0, result.output
+    config = _read_config(tmp_path)
+    assert config["default_project"] == "demo-project"

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -1,0 +1,70 @@
+"""Tests for the query command in the bq-util CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+import bq_util.cli as cli_module
+
+
+class FakeJob:
+    """Minimal stub of a BigQuery job for the CLI tests."""
+
+    job_id = "fake-job"
+    job_type = "query"
+    query = "SELECT 1"
+    total_bytes_processed = 100
+    total_bytes_billed = 100
+    slot_millis = 1000
+    cache_hit = False
+
+    def __init__(self) -> None:
+        self.referenced_tables: list[Any] = []
+
+    def to_dataframe(self):  # pragma: no cover - not expected to be used
+        raise AssertionError("to_dataframe should not be called in tests")
+
+
+def _load_config(base_dir: Path) -> dict[str, Any]:
+    config_path = base_dir / "bq_util" / "config.json"
+    return json.loads(config_path.read_text())
+
+
+def test_query_command_updates_config_and_runs_analysis(monkeypatch, tmp_path):
+    """Executing a query should store the job id and optionally analyse it."""
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    runner = CliRunner()
+
+    query_file = tmp_path / "query.sql"
+    query_file.write_text("select 1;")
+
+    fake_job = FakeJob()
+    analyze_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    monkeypatch.setattr(cli_module, "get_project", lambda project=None: "demo-project")
+    monkeypatch.setattr(
+        cli_module, "run_query", lambda query, project: (fake_job, 0.42)
+    )
+    monkeypatch.setattr(
+        cli_module, "format_query_stats", lambda job, execution_time: "stats"
+    )
+    monkeypatch.setattr(
+        cli_module, "get_query_results_preview", lambda job, max_rows=5: "preview"
+    )
+
+    def fake_analyze(job_id: str, project: str, **kwargs: Any) -> None:
+        analyze_calls.append(((job_id, project), kwargs))
+
+    monkeypatch.setattr(cli_module, "analyze_job", fake_analyze)
+
+    result = runner.invoke(cli_module.cli, ["query", str(query_file), "--analyze"])
+
+    assert result.exit_code == 0, result.output
+    config = _load_config(tmp_path)
+    assert config["last_job_id"] == "fake-job"
+    assert analyze_calls == [(("fake-job", "demo-project"), {"verbose": False})]


### PR DESCRIPTION
## Summary
- rename the CLI package and console entry point from bqutil to bq_util/bq-util
- update documentation, configuration paths, and tests to reference the new naming
- adjust project metadata and MkDocs navigation to point at the renamed assets

## Testing
- `pytest`
- `mypy src/bq_util`
- `ruff check src/bq_util tests/test_cli_config.py tests/test_cli_query.py tests/test_cli_analyze.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7f421980832cba89fbcf2f606c20)