### PR TITLE
Add Godot starter project, beginner docs, and curated resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,15 @@ docker/.env
 .aider*
 CLAUDE.md
 
+# Godot project artifacts
+.godot/
+*.import
+*.uid
+*.tmp
+*.translation
+export_presets.cfg
+.import/
+
 # Documentation build artifacts
 site/
 .cache/

--- a/README.md
+++ b/README.md
@@ -1,198 +1,70 @@
-![Code Quality Checks](https://github.com/safurrier/python-collab-template/workflows/Code%20Quality%20Checks/badge.svg) [![codecov](https://codecov.io/gh/safurrier/python-collab-template/branch/master/graph/badge.svg)](https://codecov.io/gh/safurrier/python-collab-template)
+# Godot Game Project Template
 
-# Python Project Template
-
-A modern Python project template with best practices for development and collaboration.
+A collaborative template for building Godot games with a clean project layout, starter scene, and documentation aimed at first-time Godot developers.
 
 ## Features
-- 🚀 Fast dependency management with [uv](https://github.com/astral-sh/uv)
-- ✨ Code formatting with [ruff](https://github.com/astral-sh/ruff)
-- 🔍 Type checking with [ty](https://astral.sh/blog/ty)
-- 🧪 Testing with [pytest](https://github.com/pytest-dev/pytest)
-- 🐳 Docker support for development and deployment
-- 👷 CI/CD with GitHub Actions
-
-## Python Version
-This template requires Python 3.9 or higher and defaults to Python 3.12. To use a different version:
-
-```bash
-# List available Python versions
-uv python list
-
-# Use a specific version (e.g., 3.11)
-make setup PYTHON_VERSION=3.11  # or UV_PYTHON_VERSION=3.11 make setup
-
-# View installed Python versions
-uv python list --installed
-```
-
-uv will automatically download and manage Python versions as needed.
+- 🎮 **Godot 4 starter project** with a ready-to-run `Main` scene
+- 🧭 **Beginner-friendly docs** covering editor basics, scenes, nodes, and GDScript
+- 📁 **Opinionated folder layout** for scenes, scripts, assets, and addons
+- 🚀 **Export + release guidance** for desktop and web builds
+- 🧰 **Suggested tooling** for formatting, linting, and automated checks
 
 ## Quickstart
+
+1. **Install Godot 4**
+   - Download Godot 4.x from the official website.
+   - On first launch, install export templates when prompted.
+
+2. **Open the template project**
+   ```bash
+   git clone https://github.com/your-username/your-godot-game.git
+   cd your-godot-game
+   ```
+
+3. **Launch the project in Godot**
+   - Open Godot.
+   - Click **Import** and select the `godot/` folder.
+   - The project should detect `project.godot` automatically.
+
+4. **Run the sample scene**
+   - Press **F5** or click **▶ Play**.
+   - You should see the output log message: `Godot starter pack loaded.`
+
+## Project Layout
+
+```
+your-godot-game/
+├── godot/                   # Godot project root
+│   ├── project.godot         # Godot project settings
+│   ├── scenes/               # Scene files (.tscn)
+│   ├── scripts/              # GDScript files (.gd)
+│   ├── assets/               # Art, audio, fonts
+│   └── addons/               # Plugins (GUT, GDUnit4, etc.)
+├── docs/                     # Documentation
+└── README.md
+```
+
+## Documentation
+
+The documentation is meant to be a starter pack for first-time Godot users. Key sections include:
+- **Getting Started**: install Godot, open the project, run the first scene
+- **Starter Pack Tutorial**: build a small playable scene with movement
+- **Project Structure**: learn how to organize scenes, scripts, assets, and autoloads
+- **Tooling & Exports**: format scripts, run tests, build release exports
+
+Run the docs locally (optional):
 ```bash
-# Clone this repo and change directory
-git clone git@github.com:safurrier/python-collab-template.git my-project-name
-cd my-project-name
-
-# Initialize a new project
-make init
-
-# Follow the prompts to configure your project
+make docs-serve
 ```
 
-This will:
-- Configure project metadata (name, description, author)
-- Handle example code (keep, simplify, or remove)
-- Initialize a fresh git repository
-- Set up development environment
-- Configure pre-commit hooks (optional, enabled by default)
+## Recommended Next Steps
 
-Pre-commit hooks will automatically run these checks before each commit:
-- Type checking (ty)
-- Linting (ruff)
-- Formatting (ruff)
-- Tests (pytest)
+- Replace the placeholder `Main.tscn` scene with your own gameplay scene.
+- Add player movement, camera, and collision as described in the tutorial.
+- Create export presets and build your first release.
 
-Alternatively, you can set up manually:
-```bash
-# Install dependencies and set up the environment
-make setup
-
-# Run the suite of tests and checks
-make check
-
-# Optional: Remove example code to start fresh
-make clean-example
-```
-
-## Development Commands
-
-### Quality Checks
-```bash
-make check      # Run all checks (test, ty, lint, format)
-make test       # Run tests with coverage
-make ty         # Run type checking
-make lint       # Run linter
-make format     # Run code formatter
-```
-
-### Local CI Testing
-
-Run GitHub Actions workflows locally before pushing using [act](https://github.com/nektos/act):
-
-```bash
-# Run full test suite locally (auto-installs act if needed)
-make ci-local
-
-# List available workflows
-make ci-list
-
-# Run specific job
-JOB=checks make ci-local
-
-# Run documentation build check
-make ci-local-docs
-
-# Fast debugging (customize .github/workflows/ci-debug.yml)
-make ci-debug
-
-# Clean up act containers
-make ci-clean
-```
-
-**Note:** The first run will automatically install `act` if it's not present.
-
-**Benefits:**
-- 5-20 second feedback vs. 2-5 minutes on GitHub
-- Test before commit/push
-- No GitHub Actions minutes consumed
-- Debug workflows locally
-
-**Troubleshooting:**
-
-*Linux: Docker permissions*
-```bash
-# Add your user to the docker group
-sudo usermod -aG docker $USER
-
-# Log out and back in for changes to take effect
-# Or run: newgrp docker
-
-# Verify it works
-docker ps
-```
-
-*macOS: Colima disk lock errors*
-```bash
-# If you get "disk in use" or similar errors:
-colima stop
-colima delete
-colima start
-```
-
-*General: Stale act containers*
-```bash
-# Clean up old containers and images
-make ci-clean
-```
-
-### Example Code
-The repository includes a simple example showing:
-- Type hints
-- Dataclasses
-- Unit tests
-- Modern Python practices
-
-To remove the example code and start fresh:
-```bash
-make clean-example
-```
-## Container Support (Docker/Podman)
-
-### Development Environment
-
-The project automatically detects and uses either Docker or Podman:
-
-```bash
-make dev-env    # Uses podman if available, otherwise docker
-
-# Or explicitly choose:
-CONTAINER_ENGINE=docker make dev-env
-CONTAINER_ENGINE=podman make dev-env
-
-# Check which engine will be used:
-make container-info
-```
-
-This creates a container with:
-- All dependencies installed
-- Source code mounted (changes reflect immediately)
-- Development tools ready to use
-- Automatic UID/GID mapping for file permissions
-
-### Production Image
-```bash
-make build-image    # Build production image
-make push-image     # Push to container registry
-```
-
-## Project Structure
-```
-.
-├── src/                # Source code
-├── tests/             # Test files
-├── docker/            # Container configuration (Docker/Podman)
-├── .github/           # GitHub Actions workflows
-├── pyproject.toml     # Project configuration
-└── Makefile          # Development commands
-```
-
-## Contributing
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run `make check` to ensure all tests pass
-5. Submit a pull request
+For full guidance, see the docs in `docs/`.
 
 ## License
-This project is licensed under the MIT License - see the LICENSE file for details.
+
+This project is licensed under the MIT License. See the LICENSE file for details.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,143 +1,66 @@
-# Getting Started with Python Collab Template
+# Getting Started with Godot
 
-This guide walks you through using this template to create a new Python project.
+This guide assumes you have never used Godot before. We'll walk through installing the editor, opening the template project, and understanding the basics of scenes and nodes.
 
-## Prerequisites
+## 1. Install Godot
 
-- Python 3.9 or higher
-- Git
-- GitHub account (for template usage)
+1. Download **Godot 4.x** from the official site.
+2. Launch the editor.
+3. When prompted, install **Export Templates** (this enables builds for Windows/macOS/Linux/Web).
 
-## Creating a Project from This Template
+> Tip: Godot is portable. You can keep the editor in a folder next to your project if you want a fully self-contained setup.
 
-### Step 1: Create Repository from Template
+## 2. Open the Template Project
 
-1. Go to this template repository on GitHub
-2. Click **"Use this template"** button
-3. Choose **"Create a new repository"**
-4. Fill in your repository details:
-   - Repository name (e.g., `my-awesome-project`)
-   - Description
-   - Public/Private visibility
-
-### Step 2: Clone and Initialize
-
-1. Clone your new repository:
+1. Clone the repository:
    ```bash
-   git clone https://github.com/your-username/your-project-name.git
-   cd your-project-name
+   git clone https://github.com/your-username/your-godot-game.git
+   cd your-godot-game
    ```
+2. Open Godot.
+3. Click **Import** and choose the `godot/` folder.
+4. Godot will detect `project.godot` and import the project.
 
-2. Initialize your project:
-   ```bash
-   make init
-   ```
+## 3. Run the Sample Scene
 
-3. Follow the interactive prompts:
-   - **Project name**: Enter your project name (e.g., "My Awesome Project")
-   - **Description**: Brief description of your project
-   - **Author info**: Your name and email (auto-detected from git config)
-   - **Example code**: Choose how to handle example code:
-     - Keep (useful for reference)
-     - Minimal (basic working example)
-     - Remove (clean slate)
-   - **Documentation**: Set up MkDocs documentation (default: yes)
-   - **Pre-commit hooks**: Enable quality checks on commit (default: yes)
+1. In Godot, press **F5** (or click **▶ Play**).
+2. The first time you run, Godot may ask you to select a main scene.
+3. Choose `godot/scenes/Main.tscn`.
 
-### Step 3: Verify Setup
-
-After initialization, verify everything works:
-
-```bash
-# Run all quality checks
-make check
-
-# If you enabled documentation
-make docs-serve
+You should see a log message:
+```
+Godot starter pack loaded.
 ```
 
-## Project Structure After Initialization
+## 4. Godot Basics (Quick Orientation)
 
-Your initialized project will have:
+- **Scene**: A reusable collection of nodes saved as a `.tscn` file.
+- **Node**: A building block (Sprite, Camera, CharacterBody2D, etc.).
+- **Scene Tree**: The hierarchy of nodes in the current scene.
+- **Inspector**: The panel where you edit node properties.
+- **Script**: A GDScript file (`.gd`) attached to a node.
 
+### The Minimal Loop
+
+When a scene starts, Godot calls:
+- `_ready()` once when the node enters the scene tree
+- `_process(delta)` every frame for logic
+- `_physics_process(delta)` at a fixed timestep for physics
+
+## 5. Your First Change (Hello, Godot)
+
+Open `godot/scripts/Main.gd` and update the message:
+```gdscript
+extends Node2D
+
+func _ready() -> void:
+    print("Hello from my first Godot project!")
 ```
-your-project-name/
-├── your_project_name/          # Main package (renamed from src/)
-├── tests/                      # Test files
-├── docs/                       # Documentation (if enabled)
-├── .github/workflows/          # CI/CD workflows
-├── pyproject.toml             # Project configuration
-├── Makefile                   # Development commands
-└── README.md                  # Project documentation
-```
 
-## Development Workflow
+Run the project again to see the new message.
 
-### Daily Development
+## 6. Next Steps
 
-1. Make your changes to the code
-2. Add or update tests
-3. Run quality checks:
-   ```bash
-   make check
-   ```
-4. Update documentation if needed
-5. Commit and push
-
-### Available Commands
-
-Your project comes with these make targets:
-
-- `make setup` - Set up development environment
-- `make test` - Run tests with coverage
-- `make lint` - Run linting with auto-fix
-- `make format` - Format code
-- `make ty` - Run type checking
-- `make check` - Run all quality checks
-- `make docs-serve` - Serve documentation locally (if enabled)
-- `make docs-build` - Build documentation (if enabled)
-- `make docs-check` - Validate documentation build (if enabled)
-
-### Documentation (If Enabled)
-
-If you chose to set up documentation:
-
-1. **Local development**:
-   ```bash
-   make docs-serve
-   # Visit http://localhost:8000
-   ```
-
-2. **Content organization**:
-   - `docs/index.md` - Project homepage
-   - `docs/getting-started.md` - User guide
-   - `docs/reference/api.md` - Auto-generated API docs
-
-3. **GitHub Pages setup**:
-   - Go to repository Settings → Pages
-   - Set source to "GitHub Actions"
-   - Documentation will auto-deploy on main branch pushes
-
-### CI/CD
-
-Your project includes GitHub Actions workflows:
-
-- **Quality checks** (`tests.yml`): Runs on PRs and pushes
-- **Documentation** (`docs.yml`): Deploys docs to GitHub Pages (if enabled)
-
-## Next Steps
-
-1. **Update README.md** with project-specific information
-2. **Add your code** in the main package directory
-3. **Write tests** for your functionality
-4. **Update documentation** to describe your project
-5. **Set up GitHub Pages** (if documentation enabled)
-6. **Configure repository settings** (branch protection, etc.)
-
-## Tips
-
-- The template includes example code you can reference or remove
-- All configuration follows modern Python best practices
-- The documentation system auto-generates API docs from docstrings
-- Pre-commit hooks ensure code quality before commits
-- Use `make` commands for consistent development workflow
+- Continue to the **Starter Pack Tutorial** to build a playable scene.
+- Review **Project Structure** to understand how this template organizes files.
+- Explore **Tooling & Exports** to learn how to format scripts and ship builds.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,67 +1,26 @@
-# Python Collab Template
+# Godot Game Template
 
-A modern, collaborative Python project template with comprehensive tooling and best practices built-in.
+Welcome to the Godot Game Template! This starter kit gives you a clean Godot project, an opinionated folder layout, and step-by-step documentation designed for beginners.
 
-## 🎯 Template Features
+## What You Get
 
-This template provides everything you need for a professional Python project:
+- ✅ **Ready-to-run Godot 4 project** in the `godot/` directory
+- ✅ **Starter scene + script** so you can press Play immediately
+- ✅ **Beginner tutorial** that introduces scenes, nodes, and GDScript
+- ✅ **Project structure guidance** to keep your game organized
+- ✅ **Tooling and export tips** so you can ship builds confidently
 
-- 🔧 **Modern Tooling**: UV package manager, Ruff formatting/linting, MyPy type checking
-- 🧪 **Testing**: pytest with coverage reporting and CI integration
-- 📚 **Documentation**: Optional MkDocs + Material theme with auto-generation
-- 🚀 **CI/CD**: GitHub Actions with quality checks and automated deployment
-- 🐳 **Development**: Docker support and pre-commit hooks
-- 📦 **Packaging**: Modern pyproject.toml configuration with hatchling
+## Quick Start (30 Seconds)
 
-## 🚀 Quick Start
+1. Install Godot 4.x.
+2. Import the `godot/` directory in the editor.
+3. Press **F5** to run the sample scene.
 
-### Using This Template
+## Where to Go Next
 
-1. **Create a new repository** from this template on GitHub
-2. **Clone your new repository**:
-   ```bash
-   git clone https://github.com/your-username/your-project-name.git
-   cd your-project-name
-   ```
-3. **Initialize your project**:
-   ```bash
-   make init
-   ```
-4. **Follow the prompts** to customize your project
+- 📘 **Getting Started**: install Godot, open the project, and learn the editor UI.
+- 🧰 **Starter Pack Tutorial**: build a tiny playable scene.
+- 🗂️ **Project Structure**: keep scenes, scripts, and assets tidy.
+- 🚀 **Tooling & Exports**: formatting, testing, and builds.
 
-### What `make init` Does
-
-The initialization script will:
-- Prompt for project name, description, and author information
-- Update all configuration files with your project details
-- Choose how to handle example code (keep, simplify, or remove)
-- Optionally set up MkDocs documentation (default: yes)
-- Rename directories and update imports
-- Set up git repository and pre-commit hooks
-
-## 📁 Template Structure
-
-```
-python-collab-template/
-├── src/                        # Source code (renamed during init)
-├── tests/                      # Test files
-├── scripts/                    # Utility scripts (including init)
-├── templates/                  # Documentation templates
-├── docker/                     # Docker configuration
-├── .github/workflows/          # CI/CD automation
-├── pyproject.toml             # Project configuration
-├── Makefile                   # Development commands
-└── README.md                  # Project documentation
-```
-
-## 🛠️ Available Commands
-
-After initialization, your project will have these commands:
-
-- `make setup` - Set up development environment
-- `make test` - Run tests with coverage
-- `make check` - Run all quality checks
-- `make docs-serve` - Serve documentation locally (if enabled)
-- `make docs-build` - Build documentation (if enabled)
-
-For complete usage instructions, see the [Getting Started](getting-started.md) guide.
+If you are brand new to Godot, start with **Getting Started** and move through the tutorial in order.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,0 +1,60 @@
+# Project Structure
+
+This template keeps the Godot project in a dedicated `godot/` directory so that repository-level docs, scripts, and tooling stay separate from game content.
+
+## Recommended Layout
+
+```
+Godot Game Template/
+├── godot/                       # Godot project root
+│   ├── project.godot             # Project settings
+│   ├── scenes/                   # Scene files (.tscn)
+│   │   ├── Main.tscn
+│   │   └── player/               # Feature-focused scenes
+│   ├── scripts/                  # GDScript files (.gd)
+│   ├── assets/                   # Art, audio, fonts
+│   ├── ui/                       # UI scenes and scripts
+│   ├── levels/                   # Level scenes or tilemaps
+│   ├── autoload/                 # Global singletons
+│   └── addons/                   # Plugins (GDUnit4, GUT, etc.)
+├── docs/                         # Documentation
+└── README.md
+```
+
+## Key Ideas
+
+### Scenes are Building Blocks
+Use small, reusable scenes:
+- **Player.tscn** for the player
+- **Enemy.tscn** for enemies
+- **HUD.tscn** for UI
+
+### Scripts Live Next to Scenes
+Keep scripts close to the scenes they control:
+```
+scenes/player/Player.tscn
+scripts/player/Player.gd
+```
+
+### Autoloads for Globals
+Use `autoload/` for global managers (Audio, GameState, SceneLoader). Register them in **Project Settings → Autoload**.
+
+### Asset Organization
+Organize assets by type or feature:
+```
+assets/audio/
+assets/sprites/
+assets/fonts/
+```
+
+## Naming Conventions
+
+- **Scenes**: `PascalCase.tscn` (e.g., `Player.tscn`)
+- **Scripts**: `PascalCase.gd` or `snake_case.gd`
+- **Folders**: `snake_case` or feature-based
+
+## Version Control Tips
+
+- Commit `.tscn`, `.gd`, `.tres`, `.import` settings as needed.
+- Ignore `.godot/` and generated import artifacts (already in `.gitignore`).
+- Consider Git LFS for large binary assets (audio, textures, models).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,9 +1,0 @@
-# API Reference
-
-This page contains the auto-generated API documentation for the project.
-
-::: src
-    options:
-      show_root_heading: true
-      members_order: source
-      show_source: false

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -1,0 +1,45 @@
+# Godot Resources
+
+This page is a curated starter list of the most useful Godot resources. It focuses on documentation and tooling you will reach for regularly while building your first game.
+
+## Official Docs (Start Here)
+
+- **Godot Manual**: https://docs.godotengine.org/en/stable/
+- **Class Reference**: https://docs.godotengine.org/en/stable/classes/
+- **GDScript Basics**: https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/
+- **GDScript Style Guide**: https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html
+- **Input Map**: https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html
+
+## Starter Learning Paths
+
+- **2D Game Tutorial**: https://docs.godotengine.org/en/stable/getting_started/first_2d_game/
+- **3D Game Tutorial**: https://docs.godotengine.org/en/stable/getting_started/first_3d_game/
+- **Your First Script**: https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting_first_script.html
+- **Scene Instancing**: https://docs.godotengine.org/en/stable/getting_started/step_by_step/instancing.html
+
+## Editor & Workflow
+
+- **Editor Overview**: https://docs.godotengine.org/en/stable/getting_started/introduction/editor_overview.html
+- **Project Settings**: https://docs.godotengine.org/en/stable/tutorials/editor/project_settings.html
+- **Exporting**: https://docs.godotengine.org/en/stable/tutorials/export/
+
+## Testing & Tooling
+
+- **Unit Testing with GUT**: https://github.com/bitwes/Gut
+- **Unit Testing with GDUnit4**: https://github.com/MikeSchulze/gdUnit4
+- **Formatter (gdformat)**: https://github.com/Scony/godot-gdscript-toolkit
+- **Linter (gdlint)**: https://github.com/Scony/godot-gdscript-toolkit
+
+## Asset & Community Libraries
+
+- **Godot Asset Library**: https://godotengine.org/asset-library
+- **Godot Q&A**: https://godotengine.org/qa/
+- **Godot Community**: https://godotengine.org/community/
+
+## Quick Reference Checklist
+
+- [ ] Main scene set in `project.godot`
+- [ ] Input map configured for your controls
+- [ ] Export presets saved (`export_presets.cfg`)
+- [ ] Plugins installed and documented
+- [ ] Team conventions written down (naming, scene structure, folder layout)

--- a/docs/starter-pack.md
+++ b/docs/starter-pack.md
@@ -1,0 +1,72 @@
+# Starter Pack Tutorial: Your First Playable Scene
+
+This tutorial builds a tiny 2D scene with player movement and a camera. It assumes zero Godot experience.
+
+## Goals
+
+- Add a player character
+- Move with WASD / arrow keys
+- Keep the camera centered
+
+## 1. Create a Player Scene
+
+1. In the FileSystem panel, create a new folder: `godot/scenes/player/`.
+2. Click **Scene → New Scene**.
+3. Add a **CharacterBody2D** node and name it `Player`.
+4. Add a child **Sprite2D** (for visuals) and **CollisionShape2D** (for collisions).
+5. Save the scene as `godot/scenes/player/Player.tscn`.
+
+### Add a Script
+
+Attach a new script to the `Player` node named `Player.gd` in `godot/scripts/`:
+```gdscript
+extends CharacterBody2D
+
+@export var speed: float = 300.0
+
+func _physics_process(_delta: float) -> void:
+    var input_vector = Vector2(
+        Input.get_action_strength("ui_right") - Input.get_action_strength("ui_left"),
+        Input.get_action_strength("ui_down") - Input.get_action_strength("ui_up")
+    )
+
+    velocity = input_vector.normalized() * speed
+    move_and_slide()
+```
+
+## 2. Update the Main Scene
+
+Open `godot/scenes/Main.tscn` and:
+1. Add a **Node2D** named `World`.
+2. Instance your new `Player.tscn` as a child of `World`.
+3. Add a **Camera2D** as a child of `Player`.
+4. Enable **Current** on the Camera2D so it becomes active.
+
+Your scene tree should look like:
+```
+Main (Node2D)
+└── World (Node2D)
+    └── Player (CharacterBody2D)
+        ├── Sprite2D
+        ├── CollisionShape2D
+        └── Camera2D
+```
+
+## 3. Run the Game
+
+Press **F5** to run the project. Your player should move with the arrow keys or WASD (Godot maps both to `ui_*` actions by default).
+
+## 4. Optional: Add a Floor
+
+1. In `Main.tscn`, add a **StaticBody2D** with a **CollisionShape2D**.
+2. Use a **RectangleShape2D** and scale it to make a floor.
+3. Add a **ColorRect** or **Sprite2D** for visuals.
+
+## 5. What You Learned
+
+- How to create scenes and instance them
+- How to attach scripts to nodes
+- How to move a character with built-in input actions
+- How to keep the camera centered
+
+Next, review the **Project Structure** page to learn how to organize larger games.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -17,6 +17,20 @@ Install templates from **Editor → Manage Export Templates**.
 
 Keep plugins in `godot/addons/` and commit the addon source to version control.
 
+### Installing GUT (Godot Unit Test)
+
+1. Open **AssetLib** inside the Godot editor.
+2. Search for **GUT** and click **Download**.
+3. Install it to `godot/addons/`.
+4. Enable it in **Project Settings → Plugins**.
+
+### Installing GDUnit4
+
+1. Open **AssetLib** inside the Godot editor.
+2. Search for **GDUnit4** and click **Download**.
+3. Install it to `godot/addons/`.
+4. Enable it in **Project Settings → Plugins**.
+
 ## GDScript Formatting & Linting
 
 Suggested tools (install via pip or as editor plugins):
@@ -27,6 +41,22 @@ Example commands:
 ```bash
 gdformat godot/scripts
 gdlint godot/scripts
+```
+
+### Install gdformat / gdlint
+
+The formatter and linter live in the `godot-gdscript-toolkit` project:
+
+```bash
+pip install godot-gdscript-toolkit
+```
+
+If you want isolated tooling for CI, you can install them in a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install godot-gdscript-toolkit
 ```
 
 ## Running Godot in Headless Mode

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -1,0 +1,57 @@
+# Tooling & Exports
+
+This page covers recommended tools and workflows for working on a Godot project.
+
+## Godot Editor Essentials
+
+- **Godot 4.x editor**: primary development tool.
+- **Export templates**: required to build playable binaries.
+
+Install templates from **Editor → Manage Export Templates**.
+
+## Recommended Plugins
+
+- **GDUnit4** or **GUT** for automated tests.
+- **Dialogic** for narrative-heavy projects.
+- **Godot-Redux** or custom input remapping addons for accessibility.
+
+Keep plugins in `godot/addons/` and commit the addon source to version control.
+
+## GDScript Formatting & Linting
+
+Suggested tools (install via pip or as editor plugins):
+- **gdformat** (formatter)
+- **gdlint** (lint rules)
+
+Example commands:
+```bash
+gdformat godot/scripts
+gdlint godot/scripts
+```
+
+## Running Godot in Headless Mode
+
+For CI or automated tests, use Godot's headless mode:
+```bash
+godot --headless --quit --path godot
+```
+
+## Exporting Builds
+
+1. Go to **Project → Export**.
+2. Add a preset for your target (Windows, macOS, Linux, Web).
+3. Configure:
+   - Export path
+   - Icon
+   - Compression and debug settings
+4. Click **Export Project**.
+
+Store the `export_presets.cfg` file in your repo so the settings are shared.
+
+## Build Checklist
+
+- ✅ Main scene set in `project.godot`
+- ✅ Input actions configured (Project Settings → Input Map)
+- ✅ Export presets configured
+- ✅ Version metadata in Project Settings
+- ✅ Release build tested

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -1,0 +1,14 @@
+config_version=5
+
+[application]
+config/name="Godot Starter Pack"
+run/main_scene="res://scenes/Main.tscn"
+config/features=PackedStringArray("4.2", "Forward Plus")
+
+[display]
+window/size/viewport_width=1280
+window/size/viewport_height=720
+window/size/mode=2
+
+[rendering]
+renderer/rendering_method="forward_plus"

--- a/godot/scenes/Main.tscn
+++ b/godot/scenes/Main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Main.gd" id=1]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1")

--- a/godot/scripts/Main.gd
+++ b/godot/scripts/Main.gd
@@ -1,0 +1,4 @@
+extends Node2D
+
+func _ready() -> void:
+    print("Godot starter pack loaded.")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
-site_name: Python Collab Template
-site_url: https://safurrier.github.io/python-collab-template/
-site_description: A collaborative Python project template with modern tooling
+site_name: Godot Game Template
+site_url: https://safurrier.github.io/godot-game-template/
+site_description: A beginner-friendly Godot game project template
 site_author: safurrier
 
-repo_name: safurrier/python-collab-template
-repo_url: https://github.com/safurrier/python-collab-template
+repo_name: safurrier/godot-game-template
+repo_url: https://github.com/safurrier/godot-game-template
 edit_uri: edit/main/docs/
 
 theme:
@@ -39,21 +39,10 @@ theme:
     text: Roboto
     code: Roboto Mono
   icon:
-    logo: material/library
+    logo: material/gamepad-variant
 
 plugins:
   - search
-  - mkdocstrings:
-      handlers:
-        python:
-          paths: [src]
-          options:
-            show_source: true
-            show_root_heading: true
-            merge_init_into_class: true
-            docstring_style: google
-            show_signature_annotations: true
-            separate_signature: true
 
 markdown_extensions:
   - admonition
@@ -71,10 +60,13 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Starter Pack Tutorial: starter-pack.md
+  - Project Structure: project-structure.md
+  - Tooling & Exports: tooling.md
   - Reference:
-    - API Documentation: reference/api.md
+    - Resources: reference/resources.md
 
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/safurrier/python-collab-template
+      link: https://github.com/safurrier/godot-game-template

--- a/templates/docs/getting-started.md.template
+++ b/templates/docs/getting-started.md.template
@@ -4,97 +4,40 @@ This guide will help you get started with {project_name}.
 
 ## Prerequisites
 
-- Python 3.9 or higher
+- Godot 4.x
 - Git
 
-## Installation
-
-### End Users
-
-Install from PyPI:
-```bash
-pip install {project_name}
-```
-
-### Developers
+## Open the Project
 
 1. Clone the repository:
    ```bash
    git clone https://github.com/{github_username}/{project_name}.git
    cd {project_name}
    ```
+2. Open Godot and click **Import**.
+3. Select the `godot/` directory and open the project.
 
-2. Set up the development environment:
-   ```bash
-   make setup
-   ```
+## Run the Sample Scene
 
-3. Run the tests to verify everything works:
-   ```bash
-   make test
-   ```
-
-## Basic Usage
-
-```python
-import {project_module_name}
-
-# Add your basic usage examples here
+Press **F5** to run the project. If Godot asks for a main scene, choose:
+```
+res://scenes/Main.tscn
 ```
 
-## Development Workflow
+## Your First Edit
 
-1. Make your changes to the code
-2. Add or update tests as needed
-3. Run quality checks:
-   ```bash
-   make check
-   ```
-4. Update documentation if needed
-5. Commit your changes
-6. Create a pull request
+Open `godot/scripts/Main.gd` and update the printed message:
+```gdscript
+extends Node2D
 
-## Available Commands
-
-Run `make` to see all available commands:
-
-- `make setup` - Set up development environment
-- `make test` - Run tests with coverage
-- `make lint` - Run linting
-- `make format` - Format code
-- `make ty` - Run type checking
-- `make check` - Run all quality checks
-- `make docs-serve` - Serve documentation locally
-- `make docs-build` - Build documentation
-
-## Testing
-
-Run the test suite:
-```bash
-make test
+func _ready() -> void:
+    print("Hello from my first Godot project!")
 ```
 
-Run specific tests:
-```bash
-uv run -m pytest tests/test_specific.py::test_function_name
-```
+Run again to see the updated message.
 
-## Documentation
+## Next Steps
 
-### Viewing Documentation
-
-Serve documentation locally:
-```bash
-make docs-serve
-```
-
-The documentation will be available at http://localhost:8000
-
-### Building Documentation
-
-Build static documentation:
-```bash
-make docs-build
-```
-
-The built documentation will be in the `site/` directory.
+- Follow the **Starter Pack Tutorial** to build a playable scene.
+- Review **Project Structure** to keep your project organized.
+- Visit **Tooling & Exports** to learn how to ship builds.

--- a/templates/docs/index.md.template
+++ b/templates/docs/index.md.template
@@ -2,15 +2,13 @@
 
 {project_description}
 
-## Features
+## Template Highlights
 
-- 🔧 Modern Python tooling with UV package manager
-- 🧪 Comprehensive testing with pytest
-- 🎨 Code formatting with Ruff
-- 🔍 Type checking with MyPy
-- 📚 Documentation with MkDocs + Material
-- 🚀 CI/CD with GitHub Actions
-- 🐳 Docker support for development
+- 🎮 Godot 4 starter project with a ready-to-run scene
+- 🧭 Beginner-friendly documentation and tutorial
+- 🗂️ Opinionated project structure for scenes, scripts, and assets
+- 🚀 Export and release checklist
+- 🧰 Tooling recommendations for formatting and linting
 
 ## Quick Start
 
@@ -18,66 +16,34 @@
 # Clone the repository
 git clone https://github.com/{github_username}/{project_name}.git
 cd {project_name}
-
-# Set up the development environment
-make setup
-
-# Run quality checks
-make check
 ```
 
-## Installation
-
-### For Users
-
-```bash
-pip install {project_name}
-```
-
-### For Development
-
-```bash
-# Clone the repository
-git clone https://github.com/{github_username}/{project_name}.git
-cd {project_name}
-
-# Set up development environment
-make setup
-
-# Install pre-commit hooks (optional)
-make install-hooks
-```
+Open Godot and import the `godot/` folder. Press **F5** to run the starter scene.
 
 ## Project Structure
 
 ```
 {project_name}/
-├── {project_module_name}/      # Main package
-├── tests/                      # Test files
-├── docs/                       # Documentation
-├── scripts/                    # Utility scripts
-├── docker/                     # Docker configuration
-└── .github/workflows/          # CI/CD automation
+├── godot/                   # Godot project root
+│   ├── project.godot
+│   ├── scenes/
+│   ├── scripts/
+│   ├── assets/
+│   └── addons/
+├── docs/                    # Documentation
+└── README.md
 ```
 
-## Usage
+## Documentation
 
-```python
-import {project_module_name}
-
-# Your usage examples here
-```
-
-## Development
-
-See the [Getting Started](getting-started.md) guide for detailed development instructions.
+See the [Getting Started](getting-started.md) guide for a beginner walkthrough.
 
 ## Contributing
 
 1. Fork the repository
 2. Create a feature branch
 3. Make your changes
-4. Run the test suite: `make check`
+4. Run checks (formatting, linting, tests if configured)
 5. Submit a pull request
 
 ## License

--- a/templates/docs/project-structure.md.template
+++ b/templates/docs/project-structure.md.template
@@ -1,0 +1,13 @@
+# Project Structure
+
+Document how your team organizes scenes, scripts, and assets.
+
+```
+{project_name}/
+├── godot/
+│   ├── scenes/
+│   ├── scripts/
+│   ├── assets/
+│   └── addons/
+└── docs/
+```

--- a/templates/docs/reference/api.md.template
+++ b/templates/docs/reference/api.md.template
@@ -1,9 +1,0 @@
-# API Reference
-
-This page contains the auto-generated API documentation for {project_name}.
-
-::: {project_module_name}
-    options:
-      show_root_heading: true
-      members_order: source
-      show_source: false

--- a/templates/docs/reference/resources.md.template
+++ b/templates/docs/reference/resources.md.template
@@ -1,0 +1,31 @@
+# Godot Resources
+
+Use this page to collect helpful links for your team.
+
+## Official Docs
+
+- Godot Manual: https://docs.godotengine.org/en/stable/
+- Class Reference: https://docs.godotengine.org/en/stable/classes/
+- GDScript Basics: https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/
+- GDScript Style Guide: https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html
+- Input Map: https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html
+
+## Learning Paths
+
+- 2D Game Tutorial: https://docs.godotengine.org/en/stable/getting_started/first_2d_game/
+- 3D Game Tutorial: https://docs.godotengine.org/en/stable/getting_started/first_3d_game/
+- Your First Script: https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting_first_script.html
+- Scene Instancing: https://docs.godotengine.org/en/stable/getting_started/step_by_step/instancing.html
+
+## Tooling & Testing
+
+- GUT: https://github.com/bitwes/Gut
+- GDUnit4: https://github.com/MikeSchulze/gdUnit4
+- gdformat / gdlint: https://github.com/Scony/godot-gdscript-toolkit
+
+## Team Checklists
+
+- [ ] Main scene configured
+- [ ] Input map updated
+- [ ] Export presets saved
+- [ ] Tooling documented

--- a/templates/docs/starter-pack.md.template
+++ b/templates/docs/starter-pack.md.template
@@ -1,0 +1,10 @@
+# Starter Pack Tutorial
+
+Use this page to walk new teammates through building their first playable scene.
+
+## Suggested Steps
+
+1. Create a Player scene (CharacterBody2D).
+2. Attach a movement script.
+3. Add a Camera2D and make it current.
+4. Run the project and verify controls.

--- a/templates/docs/tooling.md.template
+++ b/templates/docs/tooling.md.template
@@ -1,0 +1,15 @@
+# Tooling & Exports
+
+Summarize recommended tools, plugins, and export steps for your team.
+
+## Tooling
+
+- Godot editor version
+- Formatter/linter choices
+- Test frameworks
+
+## Export Steps
+
+1. Configure export presets
+2. Build release
+3. Verify output

--- a/templates/docs/tooling.md.template
+++ b/templates/docs/tooling.md.template
@@ -8,6 +8,12 @@ Summarize recommended tools, plugins, and export steps for your team.
 - Formatter/linter choices
 - Test frameworks
 
+### Suggested Installs
+
+- GUT: install via Godot AssetLib and enable in Project Settings → Plugins.
+- GDUnit4: install via Godot AssetLib and enable in Project Settings → Plugins.
+- gdformat / gdlint: `pip install godot-gdscript-toolkit`
+
 ## Export Steps
 
 1. Configure export presets

--- a/templates/mkdocs.yml.template
+++ b/templates/mkdocs.yml.template
@@ -39,21 +39,10 @@ theme:
     text: Roboto
     code: Roboto Mono
   icon:
-    logo: material/library
+    logo: material/gamepad-variant
 
 plugins:
   - search
-  - mkdocstrings:
-      handlers:
-        python:
-          paths: [{project_module_name}]
-          options:
-            show_source: true
-            show_root_heading: true
-            merge_init_into_class: true
-            docstring_style: google
-            show_signature_annotations: true
-            separate_signature: true
 
 markdown_extensions:
   - admonition
@@ -71,8 +60,11 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Starter Pack Tutorial: starter-pack.md
+  - Project Structure: project-structure.md
+  - Tooling & Exports: tooling.md
   - Reference:
-    - API Documentation: reference/api.md
+    - Resources: reference/resources.md
 
 extra:
   social:

--- a/tests/test_docs_setup.py
+++ b/tests/test_docs_setup.py
@@ -21,14 +21,9 @@ def test_mkdocs_dependencies_configured():
         mkdocs_deps = [dep for dep in dev_deps if "mkdocs" in dep.lower()]
         
         if mkdocs_deps:  # Only check if docs deps are present
-            assert len(mkdocs_deps) >= 2, "Should have mkdocs-material and mkdocstrings dependencies"
-            
-            # Verify specific dependencies
+            # Verify essential dependencies
             has_material = any("mkdocs-material" in dep for dep in dev_deps)
-            has_mkdocstrings = any("mkdocstrings" in dep for dep in dev_deps)
-            
             assert has_material, "Should have mkdocs-material dependency"
-            assert has_mkdocstrings, "Should have mkdocstrings dependency"
 
 
 def test_mkdocs_config_exists():
@@ -65,7 +60,6 @@ def test_mkdocs_config_valid():
             plugin_names.append(plugin)
     
     assert "search" in plugin_names, "Should have search plugin"
-    assert "mkdocstrings" in plugin_names, "Should have mkdocstrings plugin"
 
 
 def test_documentation_structure_exists():
@@ -127,7 +121,10 @@ def test_template_files_exist():
         "mkdocs.yml.template",
         "docs/index.md.template",
         "docs/getting-started.md.template",
-        "docs/reference/api.md.template",
+        "docs/starter-pack.md.template",
+        "docs/project-structure.md.template",
+        "docs/tooling.md.template",
+        "docs/reference/resources.md.template",
         ".github/workflows/docs.yml.template"
     ]
     


### PR DESCRIPTION
### Motivation

- Provide a friendly Godot 4 starter layout and beginner documentation so users can import the repo, press Play, and follow a simple tutorial. 
- Centralize a concise set of curated resources and tooling recommendations that new Godot users will reach for frequently. 
- Make the docs templates and repo tooling consistent so newly-initialized projects inherit the same guidance.

### Description

- Add a minimal Godot project under `godot/` including `project.godot`, `scenes/Main.tscn`, and `scripts/Main.gd` which prints a startup message. 
- Add beginner-focused documentation pages: `docs/getting-started.md`, `docs/starter-pack.md`, `docs/project-structure.md`, `docs/tooling.md`, and `docs/reference/resources.md`. 
- Mirror the new docs in templates by adding/updating `templates/docs/*` files (including `starter-pack.md.template`, `project-structure.md.template`, `tooling.md.template`, and `reference/resources.md.template`) and remove the old API docs template. 
- Update repository-level files: `README.md` to describe the Godot quickstart, `mkdocs.yml` to reflect the Godot site structure and theme icon, and `.gitignore` to include common Godot artifacts. 
- Adjust `tests/test_docs_setup.py` to validate the updated docs template layout and plugin expectations.

### Testing

- Ran `make check`, which ran linter/formatter/type checks and the test suite, and completed successfully (all checks passed). 
- Ran the test suite with `uv run -m pytest tests`, where the tests completed with `8 passed` and reported coverage (tests passed). 
- Built the documentation with `make docs-build` (which runs `mkdocs build --strict`) and the site was built successfully to `site/`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69699910b2cc832cb69ec23eb5996cdb)