### PR TITLE
Add core Pi Docs Bot parsing, config, policy, and validation with tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ authors = [
 ]
 requires-python = ">= 3.9"
 readme = "README.md"
-dependencies = []  # No runtime dependencies needed for example
+dependencies = [
+    "pyyaml>=6.0.2",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/src/pi_docs_bot/__init__.py
+++ b/src/pi_docs_bot/__init__.py
@@ -1,0 +1,29 @@
+"""Core primitives for the Pi Docs Bot workflow."""
+
+from .command import ParseResult, parse_comment
+from .config import PiDocsConfig, load_config
+from .policy import (
+    EffectiveSettings,
+    PolicyCheckResult,
+    allowed_paths_for_scope,
+    check_diff_limits,
+    check_path_policy,
+    resolve_settings,
+)
+from .validation import DocSystemInfo, ValidationPlan, detect_doc_systems
+
+__all__ = [
+    "DocSystemInfo",
+    "EffectiveSettings",
+    "ParseResult",
+    "PiDocsConfig",
+    "PolicyCheckResult",
+    "ValidationPlan",
+    "allowed_paths_for_scope",
+    "check_diff_limits",
+    "check_path_policy",
+    "detect_doc_systems",
+    "load_config",
+    "parse_comment",
+    "resolve_settings",
+]

--- a/src/pi_docs_bot/command.py
+++ b/src/pi_docs_bot/command.py
@@ -1,0 +1,110 @@
+"""Parsing logic for PR comment commands."""
+
+from __future__ import annotations
+
+import re
+import shlex
+
+from .models import CommentCommand, Mode, ParseResult, Scope
+
+COMMAND_PATTERN = re.compile(r"^\s*/pi\s+docs(?:\s+(?P<args>.*))?$", re.IGNORECASE)
+
+
+def parse_comment(comment_body: str) -> ParseResult:
+    """Parse a PR comment for a /pi docs command."""
+
+    match = COMMAND_PATTERN.match(comment_body.strip())
+    if not match:
+        return ParseResult(command=None)
+
+    args_text = match.group("args") or ""
+    tokens = shlex.split(args_text)
+    errors: list[str] = []
+    options: dict[str, str] = {}
+    free_text_parts: list[str] = []
+
+    for token in tokens:
+        if "=" in token:
+            key, value = token.split("=", 1)
+            options[key.strip().lower()] = value.strip()
+        else:
+            free_text_parts.append(token)
+
+    scope = _parse_scope(options.get("scope"), errors)
+    validate = _parse_bool(options.get("validate"), "validate", errors)
+    mode = _parse_mode(options.get("mode"), errors)
+    paths = _parse_paths(options.get("paths"))
+    max_files = _parse_int(options.get("max_files"), "max_files", errors)
+    max_diff_lines = _parse_int(options.get("max_diff_lines"), "max_diff_lines", errors)
+    free_text = " ".join(free_text_parts).strip()
+
+    if errors:
+        return ParseResult(command=None, errors=tuple(errors))
+
+    command = CommentCommand(
+        scope=scope,
+        validate=validate,
+        mode=mode,
+        paths=paths,
+        max_files=max_files,
+        max_diff_lines=max_diff_lines,
+        free_text=free_text,
+    )
+    return ParseResult(command=command)
+
+
+def _parse_scope(value: str | None, errors: list[str]) -> Scope | None:
+    if value is None:
+        return None
+    normalized = value.lower()
+    try:
+        return Scope(normalized)
+    except ValueError:
+        errors.append(f"Invalid scope: {value}")
+        return None
+
+
+def _parse_mode(value: str | None, errors: list[str]) -> Mode | None:
+    if value is None:
+        return None
+    normalized = value.lower()
+    try:
+        return Mode(normalized)
+    except ValueError:
+        errors.append(f"Invalid mode: {value}")
+        return None
+
+
+def _parse_bool(value: str | None, label: str, errors: list[str]) -> bool | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"true", "yes", "1"}:
+        return True
+    if normalized in {"false", "no", "0"}:
+        return False
+    errors.append(f"Invalid {label}: {value}")
+    return None
+
+
+def _parse_int(value: str | None, label: str, errors: list[str]) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        errors.append(f"Invalid {label}: {value}")
+        return None
+    if parsed < 1:
+        errors.append(f"{label} must be positive")
+        return None
+    return parsed
+
+
+def _parse_paths(value: str | None) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    parts = [part.strip() for part in value.split(",") if part.strip()]
+    if not parts:
+        return None
+    return tuple(parts)

--- a/src/pi_docs_bot/config.py
+++ b/src/pi_docs_bot/config.py
@@ -1,0 +1,83 @@
+"""Configuration loading for Pi Docs Bot."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .models import PiDocsConfig, Scope, to_tuple
+
+
+def load_config(path: Path | None = None) -> PiDocsConfig:
+    """Load .pi-docs.yaml configuration if it exists."""
+
+    config_path = path or Path(".pi-docs.yaml")
+    if not config_path.exists():
+        return PiDocsConfig()
+
+    with config_path.open("r", encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle) or {}
+
+    if not isinstance(raw, dict):
+        return PiDocsConfig()
+
+    return PiDocsConfig(
+        allowed_paths=_read_list(raw.get("allowed_paths")),
+        doc_build_command=_read_str(raw.get("doc_build_command")),
+        doc_lint_command=_read_str(raw.get("doc_lint_command")),
+        default_scope=_read_scope(raw.get("default_scope")),
+        max_files=_read_int(raw.get("max_files"), fallback=PiDocsConfig().max_files),
+        max_diff_lines=_read_int(
+            raw.get("max_diff_lines"), fallback=PiDocsConfig().max_diff_lines
+        ),
+        deny_patterns=_read_list(raw.get("deny_patterns")) or (),
+    )
+
+
+def _read_list(value: Any) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        items = [str(item) for item in value if str(item).strip()]
+        return tuple(items) if items else None
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return (cleaned,) if cleaned else None
+    return None
+
+
+def _read_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def _read_int(value: Any, fallback: int) -> int:
+    if isinstance(value, int) and value > 0:
+        return value
+    return fallback
+
+
+def _read_scope(value: Any) -> Scope:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        try:
+            return Scope(normalized)
+        except ValueError:
+            return PiDocsConfig().default_scope
+    return PiDocsConfig().default_scope
+
+
+def merge_paths(*values: tuple[str, ...] | None) -> tuple[str, ...] | None:
+    """Merge path lists in order, skipping None."""
+
+    items: list[str] = []
+    for entry in values:
+        if entry:
+            items.extend(entry)
+    return to_tuple(items) if items else None

--- a/src/pi_docs_bot/models.py
+++ b/src/pi_docs_bot/models.py
@@ -1,0 +1,106 @@
+"""Data models for the Pi Docs Bot workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Scope(str, Enum):
+    """Documentation scope for updates."""
+
+    DOCS = "docs"
+    README = "readme"
+    CHANGELOG = "changelog"
+    ALL = "all"
+
+
+class Mode(str, Enum):
+    """How to deliver the docs changes."""
+
+    STACKED = "stacked"
+    COMMIT_TO_PR_BRANCH = "commit-to-pr-branch"
+
+
+@dataclass(frozen=True)
+class CommentCommand:
+    """Parsed command options from a PR comment."""
+
+    scope: Scope | None = None
+    validate: bool | None = None
+    mode: Mode | None = None
+    paths: tuple[str, ...] | None = None
+    max_files: int | None = None
+    max_diff_lines: int | None = None
+    free_text: str = ""
+
+
+@dataclass(frozen=True)
+class ParseResult:
+    """Result of parsing a command comment."""
+
+    command: CommentCommand | None
+    errors: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PiDocsConfig:
+    """Repo-level configuration for Pi Docs Bot."""
+
+    allowed_paths: tuple[str, ...] | None = None
+    doc_build_command: str | None = None
+    doc_lint_command: str | None = None
+    default_scope: Scope = Scope.DOCS
+    max_files: int = 50
+    max_diff_lines: int = 2000
+    deny_patterns: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class EffectiveSettings:
+    """Resolved settings after applying command overrides and config."""
+
+    scope: Scope
+    validate: bool
+    mode: Mode
+    allowed_paths: tuple[str, ...]
+    max_files: int
+    max_diff_lines: int
+    deny_patterns: tuple[str, ...]
+    free_text: str
+
+
+@dataclass(frozen=True)
+class PolicyCheckResult:
+    """Result of enforcing policy constraints."""
+
+    allowed: bool
+    violations: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ValidationPlan:
+    """Validation commands to run for documentation."""
+
+    build_command: str | None
+    lint_command: str | None
+    detected_systems: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DocSystemInfo:
+    """Detected documentation systems and context."""
+
+    systems: tuple[str, ...]
+    build_command: str | None
+    lint_command: str | None
+    notes: tuple[str, ...]
+
+
+def to_tuple(values: Iterable[str] | None) -> tuple[str, ...] | None:
+    """Normalize an iterable of strings into a tuple, if provided."""
+
+    if values is None:
+        return None
+    return tuple(values)

--- a/src/pi_docs_bot/policy.py
+++ b/src/pi_docs_bot/policy.py
@@ -1,0 +1,116 @@
+"""Policy enforcement for Pi Docs Bot changes."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from fnmatch import fnmatch
+
+from .models import (
+    CommentCommand,
+    EffectiveSettings,
+    Mode,
+    PiDocsConfig,
+    PolicyCheckResult,
+    Scope,
+)
+
+
+def allowed_paths_for_scope(scope: Scope) -> tuple[str, ...]:
+    """Default allowed paths for a given scope."""
+
+    if scope == Scope.ALL:
+        return ("docs/**", "README.md", "CHANGELOG.md")
+    if scope == Scope.README:
+        return ("README.md",)
+    if scope == Scope.CHANGELOG:
+        return ("CHANGELOG.md",)
+    return ("docs/**",)
+
+
+def resolve_settings(
+    command: CommentCommand, config: PiDocsConfig
+) -> EffectiveSettings:
+    """Resolve effective settings from command overrides and config."""
+
+    scope = command.scope or config.default_scope
+    validate = True if command.validate is None else command.validate
+    mode = command.mode or Mode.STACKED
+    max_files = command.max_files or config.max_files
+    max_diff_lines = command.max_diff_lines or config.max_diff_lines
+
+    if command.paths:
+        allowed_paths = command.paths
+    elif config.allowed_paths:
+        allowed_paths = config.allowed_paths
+    else:
+        allowed_paths = allowed_paths_for_scope(scope)
+
+    return EffectiveSettings(
+        scope=scope,
+        validate=validate,
+        mode=mode,
+        allowed_paths=allowed_paths,
+        max_files=max_files,
+        max_diff_lines=max_diff_lines,
+        deny_patterns=config.deny_patterns,
+        free_text=command.free_text,
+    )
+
+
+def check_path_policy(
+    changed_paths: list[str],
+    allowed_paths: tuple[str, ...],
+    deny_patterns: tuple[str, ...] = (),
+) -> PolicyCheckResult:
+    """Ensure all changed paths are within allowed patterns."""
+
+    violations: list[str] = []
+
+    for path in changed_paths:
+        normalized = path.replace("\\", "/")
+        if _matches_any(normalized, deny_patterns):
+            violations.append(f"Denied path: {path}")
+            continue
+        if not _matches_any(normalized, allowed_paths):
+            violations.append(f"Not in allowlist: {path}")
+
+    return PolicyCheckResult(allowed=not violations, violations=tuple(violations))
+
+
+def check_diff_limits(
+    changed_file_count: int,
+    diff_line_count: int,
+    max_files: int,
+    max_diff_lines: int,
+) -> PolicyCheckResult:
+    """Check diff limits for file count and total line count."""
+
+    violations: list[str] = []
+    if changed_file_count > max_files:
+        violations.append(
+            f"Changed files ({changed_file_count}) exceed max_files ({max_files})"
+        )
+    if diff_line_count > max_diff_lines:
+        violations.append(
+            f"Diff lines ({diff_line_count}) exceed max_diff_lines ({max_diff_lines})"
+        )
+    return PolicyCheckResult(allowed=not violations, violations=tuple(violations))
+
+
+def _matches_any(path: str, patterns: tuple[str, ...]) -> bool:
+    for pattern in patterns:
+        normalized = pattern.replace("\\", "/")
+        if fnmatch(path, normalized):
+            return True
+        if normalized.startswith("**/") and fnmatch(path, normalized[3:]):
+            return True
+    return False
+
+
+def with_scope(settings: EffectiveSettings, scope: Scope) -> EffectiveSettings:
+    """Return a new settings instance with updated scope."""
+
+    updated = replace(settings, scope=scope)
+    if settings.allowed_paths == allowed_paths_for_scope(settings.scope):
+        return replace(updated, allowed_paths=allowed_paths_for_scope(scope))
+    return updated

--- a/src/pi_docs_bot/validation.py
+++ b/src/pi_docs_bot/validation.py
@@ -1,0 +1,64 @@
+"""Doc system detection and validation plan construction."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .models import DocSystemInfo, PiDocsConfig, ValidationPlan
+
+
+def detect_doc_systems(repo_root: Path, config: PiDocsConfig) -> DocSystemInfo:
+    """Detect documentation systems and recommended commands."""
+
+    systems: list[str] = []
+    notes: list[str] = []
+    build_command = config.doc_build_command
+    lint_command = config.doc_lint_command
+
+    if (repo_root / "mkdocs.yml").exists():
+        systems.append("mkdocs")
+        build_command = build_command or "mkdocs build --strict"
+    if (repo_root / "docs" / "conf.py").exists():
+        systems.append("sphinx")
+        build_command = build_command or "sphinx-build -b html docs docs/_build/html"
+
+    package_json = repo_root / "package.json"
+    if package_json.exists():
+        scripts = _read_package_scripts(package_json)
+        if "docs:build" in scripts:
+            systems.append("docusaurus")
+            build_command = build_command or "npm run docs:build"
+        if "docs:lint" in scripts:
+            lint_command = lint_command or "npm run docs:lint"
+
+    if not systems:
+        notes.append("No doc system detected")
+
+    return DocSystemInfo(
+        systems=tuple(systems),
+        build_command=build_command,
+        lint_command=lint_command,
+        notes=tuple(notes),
+    )
+
+
+def build_validation_plan(repo_root: Path, config: PiDocsConfig) -> ValidationPlan:
+    """Return a validation plan from detection and config."""
+
+    info = detect_doc_systems(repo_root, config)
+    return ValidationPlan(
+        build_command=info.build_command,
+        lint_command=info.lint_command,
+        detected_systems=info.systems,
+    )
+
+
+def _read_package_scripts(path: Path) -> dict[str, str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(data, dict) and isinstance(data.get("scripts"), dict):
+        return {str(k): str(v) for k, v in data["scripts"].items()}
+    return {}

--- a/tests/test_pi_docs_bot.py
+++ b/tests/test_pi_docs_bot.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+import yaml
+
+from src.pi_docs_bot.command import parse_comment
+from src.pi_docs_bot.config import load_config
+from src.pi_docs_bot.models import CommentCommand, Mode, PiDocsConfig, Scope
+from src.pi_docs_bot.policy import (
+    allowed_paths_for_scope,
+    check_diff_limits,
+    check_path_policy,
+    resolve_settings,
+)
+from src.pi_docs_bot.validation import build_validation_plan, detect_doc_systems
+
+
+def test_parse_comment_defaults():
+    result = parse_comment("/pi docs")
+    assert result.command is not None
+    assert result.command.scope is None
+    assert result.errors == ()
+
+
+def test_parse_comment_with_options():
+    result = parse_comment(
+        "/pi docs scope=readme validate=false mode=stacked "
+        "paths=docs,README.md max_files=10 max_diff_lines=120"
+    )
+    assert result.errors == ()
+    assert result.command == CommentCommand(
+        scope=Scope.README,
+        validate=False,
+        mode=Mode.STACKED,
+        paths=("docs", "README.md"),
+        max_files=10,
+        max_diff_lines=120,
+        free_text="",
+    )
+
+
+def test_parse_comment_invalid_values():
+    result = parse_comment("/pi docs scope=unknown validate=maybe max_files=0")
+    assert result.command is None
+    assert "Invalid scope: unknown" in result.errors
+    assert "Invalid validate: maybe" in result.errors
+    assert "max_files must be positive" in result.errors
+
+
+def test_load_config_from_yaml(tmp_path):
+    config_path = tmp_path / ".pi-docs.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "allowed_paths": ["docs/**", "README.md"],
+                "doc_build_command": "mkdocs build",
+                "default_scope": "readme",
+                "max_files": 10,
+                "deny_patterns": ["**/*.key"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = load_config(config_path)
+    assert config.allowed_paths == ("docs/**", "README.md")
+    assert config.doc_build_command == "mkdocs build"
+    assert config.default_scope == Scope.README
+    assert config.max_files == 10
+    assert config.deny_patterns == ("**/*.key",)
+
+
+def test_resolve_settings_prefers_command_over_config():
+    command = CommentCommand(scope=Scope.ALL, max_files=5)
+    config = PiDocsConfig(default_scope=Scope.README, max_files=50)
+    settings = resolve_settings(command, config)
+    assert settings.scope == Scope.ALL
+    assert settings.max_files == 5
+    assert settings.allowed_paths == allowed_paths_for_scope(Scope.ALL)
+
+
+def test_check_path_policy_respects_allowlist_and_denies():
+    result = check_path_policy(
+        ["docs/index.md", "src/app.py", "secrets.env"],
+        allowed_paths=("docs/**",),
+        deny_patterns=("**/*.env",),
+    )
+    assert result.allowed is False
+    assert "Not in allowlist: src/app.py" in result.violations
+    assert "Denied path: secrets.env" in result.violations
+
+
+def test_check_diff_limits():
+    result = check_diff_limits(5, 201, max_files=4, max_diff_lines=200)
+    assert result.allowed is False
+    assert "Changed files (5) exceed max_files (4)" in result.violations
+    assert "Diff lines (201) exceed max_diff_lines (200)" in result.violations
+
+
+def test_detect_doc_systems_and_validation_plan(tmp_path):
+    (tmp_path / "mkdocs.yml").write_text("site_name: test", encoding="utf-8")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "package.json").write_text(
+        '{"scripts": {"docs:build": "docusaurus build"}}', encoding="utf-8"
+    )
+    config = PiDocsConfig()
+    info = detect_doc_systems(tmp_path, config)
+    assert "mkdocs" in info.systems
+    assert "docusaurus" in info.systems
+    assert info.build_command is not None
+    plan = build_validation_plan(tmp_path, config)
+    assert plan.build_command == info.build_command
+
+
+def test_detect_doc_systems_none(tmp_path):
+    config = PiDocsConfig()
+    info = detect_doc_systems(tmp_path, config)
+    assert info.systems == ()
+    assert "No doc system detected" in info.notes

--- a/uv.lock
+++ b/uv.lock
@@ -684,6 +684,9 @@ wheels = [
 name = "python-collab-template"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
 
 [package.optional-dependencies]
 dev = [
@@ -707,6 +710,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.1.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
     { name = "tomli", marker = "extra == 'dev'", specifier = ">=2.0.1" },
     { name = "tomli-w", marker = "extra == 'dev'", specifier = ">=1.0.0" },


### PR DESCRIPTION
### Motivation
- Provide core library primitives to implement the Pi Docs Bot workflow that responds to `/pi docs` PR comments and produces docs-only changes scoped to a PR.
- Establish safe defaults and enforceable policy checks (allowed paths, deny patterns, diff limits) so doc runs cannot modify non-doc files or exceed configured limits.
- Detect repository doc systems and produce validation plans to allow optional doc-build / lint checks prior to opening a docs PR.

### Description
- Add a small package `src/pi_docs_bot` with modules for comment parsing (`command.py`), repo-level config loading (`config.py`), policy enforcement and settings resolution (`policy.py`), and doc-system detection + validation plan generation (`validation.py`).
- Introduce data models in `models.py` describing command options, config, effective settings, policy results, and validation artifacts.
- Implement a comment parser that recognizes `/pi docs` and options such as `scope`, `validate`, `mode`, `paths`, `max_files`, and `max_diff_lines` via `parse_comment`.
- Implement policy helpers to compute default allowlists per scope, check changed paths against allowlists/deny patterns, and enforce diff size limits.
- Implement doc system detection for `mkdocs`, `sphinx`, and script-based systems (e.g., Docusaurus via `package.json`) and build a `ValidationPlan` to expose build/lint commands.
- Add tests exercising parsing, config precedence, policy checks, and doc-system detection in `tests/test_pi_docs_bot.py` and wire PyYAML dependency support for `.pi-docs.yaml` parsing.

### Testing
- Ran the full project quality pipeline via `make check`, which ran linters, formatting, tests (`pytest`), and type checks (`ty`) and completed successfully.
- Test suite results: `pytest` ran the tests including `tests/test_pi_docs_bot.py` resulting in all tests passing (17 passed).
- Lint/format/type checks: `ruff` auto-fix/format ran and passed and `ty` type checks passed as part of `make check`.
- Added unit tests to validate parsing, config load behavior, policy enforcement, and doc-system detection; all tests succeeded in the final run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a2e02d610832c96d9fe9138de055f)